### PR TITLE
fix: call SetDefault function before parsing the flags

### DIFF
--- a/cli/assign_server_virtual_network_operation.go
+++ b/cli/assign_server_virtual_network_operation.go
@@ -39,6 +39,7 @@ func runOperationVirtualNetworkAssignmentsAssignServerVirtualNetwork(cmd *cobra.
 	}
 	// retrieve flag values from cmd and fill params
 	params := virtual_network_assignments.NewAssignServerVirtualNetworkParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationVirtualNetworkAssignmentsAssignServerVirtualNetworkAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -101,7 +101,7 @@ func MakeRootCmd() (*cobra.Command, error) {
 		return nil, err
 	}
 
-	// add login with api -oken
+	// add login with api-token
 	operationLoginCmd, err := makeOperationLoginCmd()
 	if err != nil {
 		return nil, err

--- a/cli/create_ipmi_session_operation.go
+++ b/cli/create_ipmi_session_operation.go
@@ -43,6 +43,7 @@ func runOperationIPmiCredentialsCreateIpmiSession(cmd *cobra.Command, args []str
 	}
 	// retrieve flag values from cmd and fill params
 	params := ip_m_i_credentials.NewCreateIpmiSessionParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationIPmiCredentialsCreateIpmiSessionAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/create_project_operation.go
+++ b/cli/create_project_operation.go
@@ -40,6 +40,7 @@ func runOperationProjectsCreateProject(cmd *cobra.Command, args []string) error 
 	}
 	// retrieve flag values from cmd and fill params
 	params := projects.NewCreateProjectParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationProjectsCreateProjectAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/create_server_action_operation.go
+++ b/cli/create_server_action_operation.go
@@ -43,6 +43,7 @@ func runOperationPowerActionsCreateServerAction(cmd *cobra.Command, args []strin
 	}
 	// retrieve flag values from cmd and fill params
 	params := power_actions.NewCreateServerActionParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationPowerActionsCreateServerActionAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/create_server_operation.go
+++ b/cli/create_server_operation.go
@@ -39,6 +39,7 @@ func runOperationServersCreateServer(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := servers.NewCreateServerParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationServersCreateServerAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/create_server_out_of_band_operation.go
+++ b/cli/create_server_out_of_band_operation.go
@@ -39,6 +39,7 @@ func runOperationOutOfBandCreateServerOutOfBand(cmd *cobra.Command, args []strin
 	}
 	// retrieve flag values from cmd and fill params
 	params := out_of_band.NewCreateServerOutOfBandParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationOutOfBandCreateServerOutOfBandAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/create_server_reinstall_operation.go
+++ b/cli/create_server_reinstall_operation.go
@@ -39,6 +39,7 @@ func runOperationServerReinstallCreateServerReinstall(cmd *cobra.Command, args [
 	}
 	// retrieve flag values from cmd and fill params
 	params := server_reinstall.NewCreateServerReinstallParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationServerReinstallCreateServerReinstallAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/create_virtual_network_operation.go
+++ b/cli/create_virtual_network_operation.go
@@ -40,6 +40,7 @@ func runOperationVirtualNetworksCreateVirtualNetwork(cmd *cobra.Command, args []
 	}
 	// retrieve flag values from cmd and fill params
 	params := virtual_networks.NewCreateVirtualNetworkParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationVirtualNetworksCreateVirtualNetworkAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/delete_api_key_operation.go
+++ b/cli/delete_api_key_operation.go
@@ -40,6 +40,7 @@ func runOperationAPIKeysDeleteAPIKey(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := api_keys.NewDeleteAPIKeyParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationAPIKeysDeleteAPIKeyAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/delete_project_operation.go
+++ b/cli/delete_project_operation.go
@@ -39,6 +39,7 @@ func runOperationProjectsDeleteProject(cmd *cobra.Command, args []string) error 
 	}
 	// retrieve flag values from cmd and fill params
 	params := projects.NewDeleteProjectParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationProjectsDeleteProjectAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/delete_project_ssh_key_operation.go
+++ b/cli/delete_project_ssh_key_operation.go
@@ -38,6 +38,7 @@ func runOperationSSHKeysDeleteProjectSSHKey(cmd *cobra.Command, args []string) e
 	}
 	// retrieve flag values from cmd and fill params
 	params := ssh_keys.NewDeleteProjectSSHKeyParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationSSHKeysDeleteProjectSSHKeyAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/delete_project_user_data_operation.go
+++ b/cli/delete_project_user_data_operation.go
@@ -38,6 +38,7 @@ func runOperationUserDataDeleteProjectUserData(cmd *cobra.Command, args []string
 	}
 	// retrieve flag values from cmd and fill params
 	params := user_data.NewDeleteProjectUserDataParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationUserDataDeleteProjectUserDataAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/delete_virtual_networks_assignments_operation.go
+++ b/cli/delete_virtual_networks_assignments_operation.go
@@ -40,6 +40,7 @@ func runOperationVirtualNetworkAssignmentsDeleteVirtualNetworksAssignments(cmd *
 	}
 	// retrieve flag values from cmd and fill params
 	params := virtual_network_assignments.NewDeleteVirtualNetworksAssignmentsParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationVirtualNetworkAssignmentsDeleteVirtualNetworksAssignmentsAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/delete_vpn_session_operation.go
+++ b/cli/delete_vpn_session_operation.go
@@ -40,6 +40,7 @@ func runOperationVpnSessionsDeleteVpnSession(cmd *cobra.Command, args []string) 
 	}
 	// retrieve flag values from cmd and fill params
 	params := v_p_n_sessions.NewDeleteVpnSessionParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationVpnSessionsDeleteVpnSessionAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/destroy_server_operation.go
+++ b/cli/destroy_server_operation.go
@@ -39,6 +39,7 @@ func runOperationServersDestroyServer(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := servers.NewDestroyServerParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationServersDestroyServerAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/destroy_team_member_operation.go
+++ b/cli/destroy_team_member_operation.go
@@ -39,6 +39,7 @@ func runOperationMembersDestroyTeamMember(cmd *cobra.Command, args []string) err
 	}
 	// retrieve flag values from cmd and fill params
 	params := members.NewDestroyTeamMemberParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationMembersDestroyTeamMemberAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/destroy_virtual_network_operation.go
+++ b/cli/destroy_virtual_network_operation.go
@@ -40,6 +40,7 @@ func runOperationVirtualNetworksDestroyVirtualNetwork(cmd *cobra.Command, args [
 	}
 	// retrieve flag values from cmd and fill params
 	params := virtual_networks.NewDestroyVirtualNetworkParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationVirtualNetworksDestroyVirtualNetworkAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_api_keys_operation.go
+++ b/cli/get_api_keys_operation.go
@@ -40,6 +40,7 @@ func runOperationAPIKeysGetAPIKeys(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := api_keys.NewGetAPIKeysParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationAPIKeysGetAPIKeysAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_bandwidth_plans_operation.go
+++ b/cli/get_bandwidth_plans_operation.go
@@ -39,6 +39,7 @@ func runOperationPlansGetBandwidthPlans(cmd *cobra.Command, args []string) error
 	}
 	// retrieve flag values from cmd and fill params
 	params := plans.NewGetBandwidthPlansParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationPlansGetBandwidthPlansAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_billing_usage_operation.go
+++ b/cli/get_billing_usage_operation.go
@@ -40,6 +40,7 @@ func runOperationBillingUsageGetBillingUsage(cmd *cobra.Command, args []string) 
 	}
 	// retrieve flag values from cmd and fill params
 	params := billing_usage.NewGetBillingUsageParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationBillingUsageGetBillingUsageAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_events_operation.go
+++ b/cli/get_events_operation.go
@@ -40,6 +40,7 @@ func runOperationEventsGetEvents(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := events.NewGetEventsParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationEventsGetEventsAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_ip_operation.go
+++ b/cli/get_ip_operation.go
@@ -39,6 +39,10 @@ func runOperationIPAddressesGetIP(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := ip_addresses.NewGetIPParams()
+	params.SetDefaults()
+	if err, _ := retrieveOperationIPAddressesGetIPAPIVersionFlag(params, "", cmd); err != nil {
+		return err
+	}
 	if err, _ := retrieveOperationIPAddressesGetIPExtraFieldsIPAddressesFlag(params, "", cmd); err != nil {
 		return err
 	}
@@ -64,12 +68,33 @@ func runOperationIPAddressesGetIP(cmd *cobra.Command, args []string) error {
 
 // registerOperationIPAddressesGetIPParamFlags registers all flags needed to fill params
 func registerOperationIPAddressesGetIPParamFlags(cmd *cobra.Command) error {
+	if err := registerOperationIPAddressesGetIPAPIVersionParamFlags("", cmd); err != nil {
+		return err
+	}
 	if err := registerOperationIPAddressesGetIPExtraFieldsIPAddressesParamFlags("", cmd); err != nil {
 		return err
 	}
 	if err := registerOperationIPAddressesGetIPIDParamFlags("", cmd); err != nil {
 		return err
 	}
+	return nil
+}
+
+func registerOperationIPAddressesGetIPAPIVersionParamFlags(cmdPrefix string, cmd *cobra.Command) error {
+
+	apiVersionDescription := ``
+
+	var apiVersionFlagName string
+	if cmdPrefix == "" {
+		apiVersionFlagName = "API-Version"
+	} else {
+		apiVersionFlagName = fmt.Sprintf("%v.API-Version", cmdPrefix)
+	}
+
+	var apiVersionFlagDefault string = "2023-06-01"
+
+	_ = cmd.PersistentFlags().String(apiVersionFlagName, apiVersionFlagDefault, apiVersionDescription)
+
 	return nil
 }
 
@@ -108,6 +133,26 @@ func registerOperationIPAddressesGetIPIDParamFlags(cmdPrefix string, cmd *cobra.
 	return nil
 }
 
+func retrieveOperationIPAddressesGetIPAPIVersionFlag(m *ip_addresses.GetIPParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
+	retAdded := false
+	if cmd.Flags().Changed("API-Version") {
+
+		var apiVersionFlagName string
+		if cmdPrefix == "" {
+			apiVersionFlagName = "API-Version"
+		} else {
+			apiVersionFlagName = fmt.Sprintf("%v.API-Version", cmdPrefix)
+		}
+
+		apiVersionFlagValue, err := cmd.Flags().GetString(apiVersionFlagName)
+		if err != nil {
+			return err, false
+		}
+		m.APIVersion = &apiVersionFlagValue
+
+	}
+	return nil, retAdded
+}
 func retrieveOperationIPAddressesGetIPExtraFieldsIPAddressesFlag(m *ip_addresses.GetIPParams, cmdPrefix string, cmd *cobra.Command) (error, bool) {
 	retAdded := false
 	if cmd.Flags().Changed("extra_fields[ip_addresses]") {

--- a/cli/get_ips_operation.go
+++ b/cli/get_ips_operation.go
@@ -43,6 +43,7 @@ func runOperationIPAddressesGetIps(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := ip_addresses.NewGetIpsParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationIPAddressesGetIpsAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_plan_operation.go
+++ b/cli/get_plan_operation.go
@@ -39,6 +39,7 @@ func runOperationPlansGetPlan(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := plans.NewGetPlanParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationPlansGetPlanAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_plans_operating_system_operation.go
+++ b/cli/get_plans_operating_system_operation.go
@@ -40,6 +40,7 @@ func runOperationOperatingSystemsGetPlansOperatingSystem(cmd *cobra.Command, arg
 	}
 	// retrieve flag values from cmd and fill params
 	params := operating_systems.NewGetPlansOperatingSystemParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationOperatingSystemsGetPlansOperatingSystemAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_plans_operation.go
+++ b/cli/get_plans_operation.go
@@ -40,6 +40,7 @@ func runOperationPlansGetPlans(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := plans.NewGetPlansParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationPlansGetPlansAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_project_operation.go
+++ b/cli/get_project_operation.go
@@ -40,6 +40,7 @@ func runOperationProjectsGetProject(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := projects.NewGetProjectParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationProjectsGetProjectAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_project_ssh_key_operation.go
+++ b/cli/get_project_ssh_key_operation.go
@@ -41,6 +41,7 @@ func runOperationSSHKeysGetProjectSSHKey(cmd *cobra.Command, args []string) erro
 	}
 	// retrieve flag values from cmd and fill params
 	params := ssh_keys.NewGetProjectSSHKeyParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationSSHKeysGetProjectSSHKeyAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_project_ssh_keys_operation.go
+++ b/cli/get_project_ssh_keys_operation.go
@@ -40,6 +40,7 @@ func runOperationSSHKeysGetProjectSSHKeys(cmd *cobra.Command, args []string) err
 	}
 	// retrieve flag values from cmd and fill params
 	params := ssh_keys.NewGetProjectSSHKeysParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationSSHKeysGetProjectSSHKeysAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_project_user_data_operation.go
+++ b/cli/get_project_user_data_operation.go
@@ -40,6 +40,7 @@ func runOperationUserDataGetProjectUserData(cmd *cobra.Command, args []string) e
 	}
 	// retrieve flag values from cmd and fill params
 	params := user_data.NewGetProjectUserDataParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationUserDataGetProjectUserDataAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_project_users_data_operation.go
+++ b/cli/get_project_users_data_operation.go
@@ -40,6 +40,7 @@ func runOperationUserDataGetProjectUsersData(cmd *cobra.Command, args []string) 
 	}
 	// retrieve flag values from cmd and fill params
 	params := user_data.NewGetProjectUsersDataParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationUserDataGetProjectUsersDataAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_projects_operation.go
+++ b/cli/get_projects_operation.go
@@ -40,6 +40,7 @@ func runOperationProjectsGetProjects(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := projects.NewGetProjectsParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationProjectsGetProjectsAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_region_operation.go
+++ b/cli/get_region_operation.go
@@ -39,6 +39,7 @@ func runOperationRegionsGetRegion(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := regions.NewGetRegionParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationRegionsGetRegionAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_regions_operation.go
+++ b/cli/get_regions_operation.go
@@ -41,6 +41,7 @@ func runOperationRegionsGetRegions(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := regions.NewGetRegionsParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationRegionsGetRegionsAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_role_id_operation.go
+++ b/cli/get_role_id_operation.go
@@ -39,6 +39,7 @@ func runOperationRolesGetRoleID(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := roles.NewGetRoleIDParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationRolesGetRoleIDAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_roles_operation.go
+++ b/cli/get_roles_operation.go
@@ -40,6 +40,7 @@ func runOperationRolesGetRoles(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := roles.NewGetRolesParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationRolesGetRolesAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_server_deploy_config_operation.go
+++ b/cli/get_server_deploy_config_operation.go
@@ -39,6 +39,7 @@ func runOperationDeployConfigGetServerDeployConfig(cmd *cobra.Command, args []st
 	}
 	// retrieve flag values from cmd and fill params
 	params := deploy_config.NewGetServerDeployConfigParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationDeployConfigGetServerDeployConfigAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_server_operation.go
+++ b/cli/get_server_operation.go
@@ -40,6 +40,7 @@ func runOperationServersGetServer(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := servers.NewGetServerParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationServersGetServerAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_server_out_of_band_operation.go
+++ b/cli/get_server_out_of_band_operation.go
@@ -39,6 +39,7 @@ func runOperationOutOfBandGetServerOutOfBand(cmd *cobra.Command, args []string) 
 	}
 	// retrieve flag values from cmd and fill params
 	params := out_of_band.NewGetServerOutOfBandParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationOutOfBandGetServerOutOfBandAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_servers_operation.go
+++ b/cli/get_servers_operation.go
@@ -40,6 +40,7 @@ func runOperationServersGetServers(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := servers.NewGetServersParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationServersGetServersAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_team_members_operation.go
+++ b/cli/get_team_members_operation.go
@@ -39,6 +39,7 @@ func runOperationMembersGetTeamMembers(cmd *cobra.Command, args []string) error 
 	}
 	// retrieve flag values from cmd and fill params
 	params := members.NewGetTeamMembersParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationMembersGetTeamMembersAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_team_operation.go
+++ b/cli/get_team_operation.go
@@ -39,6 +39,7 @@ func runOperationTeamsGetTeam(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := teams.NewGetTeamParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationTeamsGetTeamAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_traffic_consumption_operation.go
+++ b/cli/get_traffic_consumption_operation.go
@@ -39,6 +39,7 @@ func runOperationBandwidthGetTrafficConsumption(cmd *cobra.Command, args []strin
 	}
 	// retrieve flag values from cmd and fill params
 	params := bandwidth.NewGetTrafficConsumptionParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationBandwidthGetTrafficConsumptionAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_traffic_quota_operation.go
+++ b/cli/get_traffic_quota_operation.go
@@ -39,6 +39,7 @@ func runOperationBandwidthGetTrafficQuota(cmd *cobra.Command, args []string) err
 	}
 	// retrieve flag values from cmd and fill params
 	params := bandwidth.NewGetTrafficQuotaParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationBandwidthGetTrafficQuotaAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_user_profile_operation.go
+++ b/cli/get_user_profile_operation.go
@@ -41,6 +41,7 @@ func runOperationAccountGetUserProfile(cmd *cobra.Command, args []string) error 
 	}
 	// retrieve flag values from cmd and fill params
 	params := account.NewGetUserProfileParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationAccountGetUserProfileAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_user_teams_operation.go
+++ b/cli/get_user_teams_operation.go
@@ -40,6 +40,7 @@ func runOperationAccountGetUserTeams(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := account.NewGetUserTeamsParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationAccountGetUserTeamsAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_virtual_network_operation.go
+++ b/cli/get_virtual_network_operation.go
@@ -41,6 +41,7 @@ func runOperationVirtualNetworksGetVirtualNetwork(cmd *cobra.Command, args []str
 	}
 	// retrieve flag values from cmd and fill params
 	params := virtual_networks.NewGetVirtualNetworkParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationVirtualNetworksGetVirtualNetworkAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_virtual_networks_assignments_operation.go
+++ b/cli/get_virtual_networks_assignments_operation.go
@@ -40,6 +40,7 @@ func runOperationVirtualNetworkAssignmentsGetVirtualNetworksAssignments(cmd *cob
 	}
 	// retrieve flag values from cmd and fill params
 	params := virtual_network_assignments.NewGetVirtualNetworksAssignmentsParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationVirtualNetworkAssignmentsGetVirtualNetworksAssignmentsAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_virtual_networks_operation.go
+++ b/cli/get_virtual_networks_operation.go
@@ -40,6 +40,7 @@ func runOperationVirtualNetworksGetVirtualNetworks(cmd *cobra.Command, args []st
 	}
 	// retrieve flag values from cmd and fill params
 	params := virtual_networks.NewGetVirtualNetworksParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationVirtualNetworksGetVirtualNetworksAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/get_vpn_sessions_operation.go
+++ b/cli/get_vpn_sessions_operation.go
@@ -39,6 +39,7 @@ func runOperationVpnSessionsGetVpnSessions(cmd *cobra.Command, args []string) er
 	}
 	// retrieve flag values from cmd and fill params
 	params := v_p_n_sessions.NewGetVpnSessionsParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationVpnSessionsGetVpnSessionsAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/patch_current_team_operation.go
+++ b/cli/patch_current_team_operation.go
@@ -40,6 +40,7 @@ func runOperationTeamsPatchCurrentTeam(cmd *cobra.Command, args []string) error 
 	}
 	// retrieve flag values from cmd and fill params
 	params := teams.NewPatchCurrentTeamParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationTeamsPatchCurrentTeamAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/patch_user_profile_operation.go
+++ b/cli/patch_user_profile_operation.go
@@ -41,6 +41,7 @@ func runOperationAccountPatchUserProfile(cmd *cobra.Command, args []string) erro
 	}
 	// retrieve flag values from cmd and fill params
 	params := account.NewPatchUserProfileParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationAccountPatchUserProfileAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/post_api_key_operation.go
+++ b/cli/post_api_key_operation.go
@@ -41,6 +41,7 @@ func runOperationAPIKeysPostAPIKey(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := api_keys.NewPostAPIKeyParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationAPIKeysPostAPIKeyAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/post_project_ssh_key_operation.go
+++ b/cli/post_project_ssh_key_operation.go
@@ -41,6 +41,7 @@ func runOperationSSHKeysPostProjectSSHKey(cmd *cobra.Command, args []string) err
 	}
 	// retrieve flag values from cmd and fill params
 	params := ssh_keys.NewPostProjectSSHKeyParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationSSHKeysPostProjectSSHKeyAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/post_project_user_data_operation.go
+++ b/cli/post_project_user_data_operation.go
@@ -40,6 +40,7 @@ func runOperationUserDataPostProjectUserData(cmd *cobra.Command, args []string) 
 	}
 	// retrieve flag values from cmd and fill params
 	params := user_data.NewPostProjectUserDataParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationUserDataPostProjectUserDataAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/post_team_members_operation.go
+++ b/cli/post_team_members_operation.go
@@ -39,6 +39,7 @@ func runOperationMembersPostTeamMembers(cmd *cobra.Command, args []string) error
 	}
 	// retrieve flag values from cmd and fill params
 	params := members.NewPostTeamMembersParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationMembersPostTeamMembersAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/post_team_operation.go
+++ b/cli/post_team_operation.go
@@ -40,6 +40,7 @@ func runOperationTeamsPostTeam(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := teams.NewPostTeamParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationTeamsPostTeamAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/post_vpn_session_operation.go
+++ b/cli/post_vpn_session_operation.go
@@ -41,6 +41,7 @@ func runOperationVpnSessionsPostVpnSession(cmd *cobra.Command, args []string) er
 	}
 	// retrieve flag values from cmd and fill params
 	params := v_p_n_sessions.NewPostVpnSessionParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationVpnSessionsPostVpnSessionAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/put_project_ssh_key_operation.go
+++ b/cli/put_project_ssh_key_operation.go
@@ -41,6 +41,7 @@ func runOperationSSHKeysPutProjectSSHKey(cmd *cobra.Command, args []string) erro
 	}
 	// retrieve flag values from cmd and fill params
 	params := ssh_keys.NewPutProjectSSHKeyParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationSSHKeysPutProjectSSHKeyAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/put_project_user_data_operation.go
+++ b/cli/put_project_user_data_operation.go
@@ -40,6 +40,7 @@ func runOperationUserDataPutProjectUserData(cmd *cobra.Command, args []string) e
 	}
 	// retrieve flag values from cmd and fill params
 	params := user_data.NewPutProjectUserDataParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationUserDataPutProjectUserDataAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/put_vpn_session_operation.go
+++ b/cli/put_vpn_session_operation.go
@@ -40,6 +40,7 @@ func runOperationVpnSessionsPutVpnSession(cmd *cobra.Command, args []string) err
 	}
 	// retrieve flag values from cmd and fill params
 	params := v_p_n_sessions.NewPutVpnSessionParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationVpnSessionsPutVpnSessionAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/server_exit_rescue_mode_operation.go
+++ b/cli/server_exit_rescue_mode_operation.go
@@ -39,6 +39,7 @@ func runOperationRescueModeServerExitRescueMode(cmd *cobra.Command, args []strin
 	}
 	// retrieve flag values from cmd and fill params
 	params := rescue_mode.NewServerExitRescueModeParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationRescueModeServerExitRescueModeAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/server_schedule_deletion_operation.go
+++ b/cli/server_schedule_deletion_operation.go
@@ -39,6 +39,7 @@ func runOperationServersServerScheduleDeletion(cmd *cobra.Command, args []string
 	}
 	// retrieve flag values from cmd and fill params
 	params := servers.NewServerScheduleDeletionParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationServersServerScheduleDeletionAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/server_start_rescue_mode_operation.go
+++ b/cli/server_start_rescue_mode_operation.go
@@ -39,6 +39,7 @@ func runOperationRescueModeServerStartRescueMode(cmd *cobra.Command, args []stri
 	}
 	// retrieve flag values from cmd and fill params
 	params := rescue_mode.NewServerStartRescueModeParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationRescueModeServerStartRescueModeAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/server_unschedule_deletion_operation.go
+++ b/cli/server_unschedule_deletion_operation.go
@@ -39,6 +39,7 @@ func runOperationServersServerUnscheduleDeletion(cmd *cobra.Command, args []stri
 	}
 	// retrieve flag values from cmd and fill params
 	params := servers.NewServerUnscheduleDeletionParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationServersServerUnscheduleDeletionAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/update_api_key_operation.go
+++ b/cli/update_api_key_operation.go
@@ -41,6 +41,7 @@ func runOperationAPIKeysUpdateAPIKey(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := api_keys.NewUpdateAPIKeyParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationAPIKeysUpdateAPIKeyAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/update_plans_bandwidth_operation.go
+++ b/cli/update_plans_bandwidth_operation.go
@@ -40,6 +40,7 @@ func runOperationBandwidthPackagesUpdatePlansBandwidth(cmd *cobra.Command, args 
 	}
 	// retrieve flag values from cmd and fill params
 	params := bandwidth_packages.NewUpdatePlansBandwidthParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationBandwidthPackagesUpdatePlansBandwidthAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/update_project_operation.go
+++ b/cli/update_project_operation.go
@@ -40,6 +40,7 @@ func runOperationProjectsUpdateProject(cmd *cobra.Command, args []string) error 
 	}
 	// retrieve flag values from cmd and fill params
 	params := projects.NewUpdateProjectParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationProjectsUpdateProjectAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/update_server_deploy_config_operation.go
+++ b/cli/update_server_deploy_config_operation.go
@@ -39,6 +39,7 @@ func runOperationDeployConfigUpdateServerDeployConfig(cmd *cobra.Command, args [
 	}
 	// retrieve flag values from cmd and fill params
 	params := deploy_config.NewUpdateServerDeployConfigParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationDeployConfigUpdateServerDeployConfigAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/update_server_operation.go
+++ b/cli/update_server_operation.go
@@ -39,6 +39,7 @@ func runOperationServersUpdateServer(cmd *cobra.Command, args []string) error {
 	}
 	// retrieve flag values from cmd and fill params
 	params := servers.NewUpdateServerParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationServersUpdateServerAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/cli/update_virtual_network_operation.go
+++ b/cli/update_virtual_network_operation.go
@@ -40,6 +40,7 @@ func runOperationVirtualNetworksUpdateVirtualNetwork(cmd *cobra.Command, args []
 	}
 	// retrieve flag values from cmd and fill params
 	params := virtual_networks.NewUpdateVirtualNetworkParams()
+	params.SetDefaults()
 	if err, _ := retrieveOperationVirtualNetworksUpdateVirtualNetworkAPIVersionFlag(params, "", cmd); err != nil {
 		return err
 	}

--- a/client/ip_addresses/get_ip_parameters.go
+++ b/client/ip_addresses/get_ip_parameters.go
@@ -61,6 +61,9 @@ GetIPParams contains all the parameters to send to the API endpoint
 */
 type GetIPParams struct {
 
+	// Default: "2023-06-01"
+	APIVersion *string
+
 	/* ExtraFieldsIPAddresses.
 
 	   The `region` and `server` are provided as extra attributes that is lazy loaded. To request it, just set `extra_fields[ip_addresses]=region,server` in the query string.


### PR DESCRIPTION
Hydrate parameters by calling params.SetDefaults() before parsing the flags.

This should enforce that we Always send API-Version "2023-06-01" in the header of our requests