### PR TITLE
fix: set API-Version default globally

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -309,7 +309,9 @@ func makeAuthInfoWriter(cmd *cobra.Command) (runtime.ClientAuthInfoWriter, error
 	/*Authorization */
 	if viper.IsSet("Authorization") {
 		AuthorizationKey := viper.GetString("Authorization")
+		ApiVersion := viper.GetString("api-version")
 		auths = append(auths, httptransport.APIKeyAuth("Authorization", "header", AuthorizationKey))
+		auths = append(auths, httptransport.APIKeyAuth("API-Version", "header", ApiVersion))
 	}
 	if len(auths) == 0 {
 		logDebugf("Warning: No auth params detected.")

--- a/cli/login.go
+++ b/cli/login.go
@@ -45,6 +45,7 @@ func runOperationLogin(cmd *cobra.Command, args []string) error {
 	}
 	defer f.Close()
 
+	viper.Set("API-Version", "2023-06-01")
 	viper.Set("authorization", args[0])
 	viper.WriteConfig()
 	fmt.Println("Success, configuration file updated!")


### PR DESCRIPTION
Enforce that we Always send API-Version "2023-06-01" in the header of our requests.