### PR TITLE
Fix: Print only the JSON result for successful responses

### DIFF
--- a/internal/utils/response_utils.go
+++ b/internal/utils/response_utils.go
@@ -57,7 +57,14 @@ func PrintOutput(jsonData string) {
 		// Format and display the errors
 		printError(errorResponse.Errors)
 	} else {
-		fmt.Println(PrettifyJson(jsonData))
+		prettyJSON, err := PrettifyJson(jsonData)
+
+		if err != nil {
+			fmt.Println("Error when parsing the response data")
+			return
+		}
+
+		fmt.Println(prettyJSON)
 	}
 }
 


### PR DESCRIPTION
This PR modifies the `PrintOutput` function to print only the JSON content for successful responses. Previously, it was printing both the returned values of `PrettifyJson`: the JSON itself and `nil` (the error).


**How to test it**

- Make a valid request to any endpoint
- [ ] It should return only the JSON content