### PR TITLE
Feat: Create an initial version of an installation script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+OS=$(uname -s)
+ARCH=$(uname -m)
+BASE_FILENAME="lsh_%s_%s"
+FILENAME=$(printf "$BASE_FILENAME" "$OS" "$ARCH")
+STABLE_VERSION=v0.0.1
+URL="https://github.com/latitudesh/lsh/releases/download/$STABLE_VERSION/$FILENAME.tar.gz"
+
+echo -e "[lsh] Download started!\n"
+curl -L -o lsh.tar.gz $URL
+echo -e "[lsh] Download finished!\n"
+
+echo -e "[lsh] Setting up the CLI\n"
+HOME_DIR=$(echo ~)
+INSTALL_DIR="$HOME_DIR/.lsh"
+mkdir -p $INSTALL_DIR
+tar -xzf lsh.tar.gz
+mv "$FILENAME/lsh" $INSTALL_DIR
+
+
+# Detect the current shell and add the directory to the user's PATH
+SHELL_NAME=$(basename "$SHELL")
+
+SHELL_CONFIG_PATH=""
+
+case "$SHELL_NAME" in
+    "bash")
+        SHELL_CONFIG_PATH=~/.bashrc
+        echo "export PATH=$PATH:$HOME_DIR/.lsh" >> $SHELL_CONFIG_PATH
+        ;;
+    "zsh")
+        SHELL_CONFIG_PATH=~/.zshrc
+        echo "export PATH=$PATH:$HOME_DIR/.lsh" >> $SHELL_CONFIG_PATH
+        ;;
+    "fish")
+        SHELL_CONFIG_PATH=~/.config/fish/config.fish
+        echo 'set -gx PATH $PATH $HOME_DIR/.lsh' >> $SHELL_CONFIG_PATH
+        ;;
+    *)
+        echo "Unsupported shell: $SHELL_NAME"
+        ;;
+esac
+
+echo -e "[lsh] Removing installation files\n"
+rm lsh.tar.gz
+rm -rf $FILENAME
+
+echo -e "[lsh] Installation finished! To enable the lsh command, run: \n"
+echo -e "    source $SHELL_CONFIG_PATH \n"


### PR DESCRIPTION
### What

This PR creates a file named `install.sh` to automate part of the process to install the CLI.

A few points to consider:

- The script relies on the available releases, and for now, is hard-coded to use v0.1.0. We'll have to make it dynamic soon
- For now, the script is only supported for Mac OS and Linux. There will be subsequent PRs to add support to Windows as well
- We'll also need better error handling for this script (currently, it prints that the action was successful, even when there's a failure on the installation process)

### How to test

- First, make sure to remove `lsh` if you already installed it
- Then, run this command:

```sh
curl -sSL https://raw.githubusercontent.com/latitudesh/lsh/feat/installation-script/install.sh?token=GHSAT0AAAAAACHXWPABDSOGSIMFTRNIYVHCZNROTHA | bash
```

- You should see no errors, and a message to run a `source` command.
- After running the `source` command, the `lsh` command should be available