### PR TITLE
chore(goreleaser): enable pull_request creation for Homebrew tap

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -59,4 +59,5 @@ brews:
     repository:
       owner: latitudesh
       name: homebrew-tools
-
+    pull_request:
+      enabled: true


### PR DESCRIPTION
## What was changed

This PR updates the `.goreleaser.yaml` file to enable automatic pull request creation when publishing new releases that update the Homebrew formula in [latitudesh/homebrew-tools](https://github.com/latitudesh/homebrew-tools).

Instead of pushing directly to the main branch of the tap (which is now protected), GoReleaser will:
- Create a new branch
- Push the updated lsh.rb formula
- Open a pull request for review and merge