### PR TITLE
build(goreleaser): migrate to config schema v2 and enable PR for Homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,10 @@ jobs:
           go-version: '1.21.6'
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,6 +6,8 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
+version: 2
+
 before:
   hooks:
     - go mod tidy
@@ -23,19 +25,13 @@ builds:
       - darwin
 
 archives:
-  - format: tar.gz
-    # this name template makes the OS and Arch compatible with the results of `uname`.
-    name_template: >-
+  - name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    # use zip for windows archives
-    format_overrides:
-      - goos: windows
-        format: zip
     files:
       - src: license*
       - src: LICENSE*
@@ -44,8 +40,6 @@ archives:
     wrap_in_directory: true
 checksum:
   name_template: "checksums.txt"
-snapshot:
-  name_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:
@@ -53,11 +47,13 @@ changelog:
       - "^docs:"
       - "^test:"
 
-brews:
-  - name: lsh
+homebrew_casks:
+ -
+    name: lsh
     homepage: "https://www.latitude.sh/"
+
     repository:
       owner: latitudesh
       name: homebrew-tools
-    pull_request:
-      enabled: true
+      pull_request:
+        enabled: true


### PR DESCRIPTION
## What was changed

This PR updates the `.goreleaser.yaml` file and the GitHub Actions workflow to migrate the GoReleaser configuration to version 2 schema and enable automatic pull request creation for Homebrew formula updates in [latitudesh/homebrew-tools](https://github.com/latitudesh/homebrew-tools).

Instead of pushing directly to the main branch of the tap (which is now protected), GoReleaser will:

- Use the new `homebrew_casks` config (replacing deprecated `brews`)
- Create a new branch with the updated `lsh.rb` formula
- Open a pull request for review and merge

The workflow also now uses `goreleaser-action@v6` locked to GoReleaser version `~> v2` to support these features.