### PR TITLE
fix(goreleaser): downgrade to v1.26.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,10 @@ jobs:
           go-version: '1.21.6'
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
-          version: '~> v2'
+          version: 'v1.26.2'
           args: release --clean --config .goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,8 +6,6 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
-version: 2
-
 before:
   hooks:
     - go mod tidy
@@ -47,7 +45,7 @@ changelog:
       - "^docs:"
       - "^test:"
 
-homebrew_casks:
+brews:
   -
     name: lsh
     homepage: "https://www.latitude.sh/"
@@ -55,5 +53,6 @@ homebrew_casks:
     repository:
       owner: latitudesh
       name: homebrew-tools
+      branch: main
       pull_request:
         enabled: true


### PR DESCRIPTION
## Whats was changed

This PR downgrades GoReleaser to version `v1.26.2` to restore compatibility with the current `.goreleaser.yaml` configuration. The change addresses issues encountered when attempting to open pull requests to the `homebrew-tools` tap, caused by the use of `homebrew_casks`, which is not supported in GoReleaser v1.