### PR TITLE
chore(goreleaser): add project_name to configuration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,6 +6,8 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
+project_name: lsh
+
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
### What does this PR do?

This PR updates the GoReleaser configuration by adding the `project_name` field and setting it to `lsh`.