### PR TITLE
fix(cli): lowercase hostname

### DIFF
--- a/cli/create_server_reinstall_operation.go
+++ b/cli/create_server_reinstall_operation.go
@@ -66,7 +66,7 @@ func (o *CreateServerReinstallOperation) registerFlags(cmd *cobra.Command) {
 			Options:     server.SupportedOperatingSystems,
 		},
 		&cmdflag.String{
-			Name:        "Hostname",
+			Name:        "hostname",
 			Label:       "",
 			Description: "The server hostname",
 			Required:    false,


### PR DESCRIPTION
### What does this PR do?

Renames the CLI flag from `Hostname` to `hostname`.