### PR TITLE
fix: JSON output flags (--json, -o json)

### DIFF
--- a/cli/new_plans_list.go
+++ b/cli/new_plans_list.go
@@ -178,15 +178,15 @@ func newPlansAvailabilityCmd() *cobra.Command {
 // --- Grouped Plans (for plans list command) ---
 
 type groupedPlan struct {
-	Slug        string
-	CPU         string
-	Drives      string
-	NIC         string
-	ID          string
-	AvailableIn []string
-	InStock     []string
-	Features    []string
-	Memory      string
+	Slug        string   `json:"slug"`
+	CPU         string   `json:"cpu"`
+	Drives      string   `json:"drives"`
+	NIC         string   `json:"nic"`
+	ID          string   `json:"id"`
+	AvailableIn []string `json:"available_in"`
+	InStock     []string `json:"in_stock"`
+	Features    []string `json:"features"`
+	Memory      string   `json:"memory"`
 }
 
 func groupPlans(pr *plansResponse, gpu bool, name, slug string, inStock bool, location, stockLevel string, diskEql, diskGte, diskLte, ramEql, ramGte, ramLte int) []groupedPlan {
@@ -350,6 +350,12 @@ func renderGroupedPlans(plans []groupedPlan) {
 		return
 	}
 
+	// Check if JSON output was requested
+	if viper.GetBool("json") || viper.GetString("output") == "json" {
+		renderGroupedPlansJSON(plans)
+		return
+	}
+
 	if os.Getenv("LSH_CLASSIC_OUTPUT") == "true" {
 		renderGroupedPlansClassic(plans)
 		return
@@ -449,6 +455,15 @@ func wrapLocationsSmartLimit(locs []string, maxDisplay int) string {
 	displayed := strings.Join(locs[:maxDisplay], ", ")
 	remaining := len(locs) - maxDisplay
 	return fmt.Sprintf("%s, +%d", displayed, remaining)
+}
+
+func renderGroupedPlansJSON(plans []groupedPlan) {
+	jsonData, err := json.MarshalIndent(plans, "", "    ")
+	if err != nil {
+		fmt.Println("Could not encode plans as JSON.")
+		return
+	}
+	fmt.Println(string(jsonData))
 }
 
 func renderGroupedPlansClassic(plans []groupedPlan) {

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,8 @@ require (
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a // indirect
 	golang.org/x/sync v0.11.0 // indirect
-	golang.org/x/sys v0.36.0 // indirect
+	golang.org/x/sys v0.38.0 // indirect
+	golang.org/x/term v0.37.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,12 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
 golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
+golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.37.0 h1:8EGAD0qCmHYZg6J17DvsMy9/wJ7/D/4pV/wfnld5lTU=
+golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/internal/renderer/json.go
+++ b/internal/renderer/json.go
@@ -4,24 +4,26 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-
-	"github.com/go-openapi/swag"
 )
 
 type JSONRenderer struct{}
 
 func (jr JSONRenderer) Render(data []ResponseData) {
-	if !swag.IsZero(data) {
-		JSONString, err := json.Marshal(data)
-		if err != nil {
-			fmt.Println("Could not decode the result as JSON.")
-		}
-
-		var prettyJSON bytes.Buffer
-		if err := json.Indent(&prettyJSON, JSONString, "", "    "); err != nil {
-			fmt.Println("JSON format error")
-		}
-
-		fmt.Println(prettyJSON.String())
+	if len(data) == 0 {
+		return
 	}
+
+	JSONString, err := json.Marshal(data)
+	if err != nil {
+		fmt.Println("Could not decode the result as JSON.")
+		return
+	}
+
+	var prettyJSON bytes.Buffer
+	if err := json.Indent(&prettyJSON, JSONString, "", "    "); err != nil {
+		fmt.Println("JSON format error")
+		return
+	}
+
+	fmt.Println(prettyJSON.String())
 }

--- a/internal/renderer/main.go
+++ b/internal/renderer/main.go
@@ -5,6 +5,7 @@ import (
 
 	outputTable "github.com/latitudesh/lsh/internal/output/table"
 	"github.com/spf13/viper"
+	"golang.org/x/term"
 )
 
 type ResponseData interface {
@@ -22,10 +23,14 @@ func GetRenderer() Renderer {
 		return TableRenderer{} // Old ASCII
 	}
 
-	// Check if JSON was requested
-	if viper.GetBool("json") {
-		// You can create a JSONRenderer later
-		return TableRenderer{} // fallback
+	// Check if JSON was requested via --json flag or -o json
+	if viper.GetBool("json") || viper.GetString("output") == "json" {
+		return JSONRenderer{}
+	}
+
+	// If stdout is not a terminal (e.g., pipe), use table output
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		return TableRenderer{}
 	}
 
 	// Default: use interactive Bubble Tea


### PR DESCRIPTION
## Summary
- Fix `--json` and `-o json` flags that were not producing JSON output
- `GetRenderer()` was returning `TableRenderer` instead of `JSONRenderer` when JSON flags were set
- `plans list` command had separate rendering logic that didn't check JSON flags
- Add terminal detection to fallback to table output when piping (prevents TUI issues)

## Test plan
- [x] `lsh servers list --json` outputs JSON
- [x] `lsh servers list -o json` outputs JSON
- [x] `lsh plans list --json` outputs JSON
- [x] `lsh plans list -o json` outputs JSON
- [x] `go build ./...` passes

## Reference
- https://www.latitude.sh/docs/cli/examples