### PR TITLE
docs: document plans stock command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,30 @@ lsh plans list --gpu true
 
 ```
 
+Check plan availability per location (one row per plan × location, with `stock_level`):
+
+```bash
+lsh plans stock
+```
+
+Show only locations that currently have stock:
+
+```bash
+lsh plans stock --in_stock
+```
+
+Filter by region, GPU, or hardware spec and export as CSV:
+
+```bash
+lsh plans stock --region "United States" --in_stock --format csv > us_plans.csv
+```
+
+Combine filters for scripting with `jq` (use `--format json` when piping — the default table requires a TTY):
+
+```bash
+lsh plans stock --gpu --ram_gte 64 --format json | jq '.[] | {plan: .plan_slug, loc: .location, stock: .stock_level}'
+```
+
 List volumes:
 
 ```bash


### PR DESCRIPTION
## Summary
- Add README examples for `lsh plans stock` — per-location plan availability (basic, `--in_stock`, CSV export with region filter, JSON + jq for scripting).
- Mention the TTY requirement of the default table format so scripts know to use `--format json|csv` instead.

Context: the command has been quietly available for a while (latest fix `abf792d` — derive stock level per location), but isn't referenced anywhere in the README today, so users have no way to discover it.

## Test plan
- [x] `lsh plans stock` — returns rows (table in a TTY)
- [x] `lsh plans stock --in_stock --format json | jq length` — non-zero
- [x] `lsh plans stock --region "United States" --in_stock --format csv > /tmp/plans.csv && head /tmp/plans.csv`
- [x] `lsh plans stock --gpu --ram_gte 64 --format json | jq '.[] | {plan: .plan_slug, loc: .location, stock: .stock_level}'`