### PR TITLE
feat(cli): teams, regions, ips and operating-systems commands + SDK v1.15.0 (PD-6080)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.0'
+          go-version-file: go.mod
       -
         name: Remove conflicting go.mod
         run: |
@@ -53,7 +53,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.0'
+          go-version-file: go.mod
       -
         name: Remove conflicting go.mod
         run: |

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -157,6 +157,12 @@ func MakeRootCmd(rootCmd *cobra.Command) (*cobra.Command, error) {
 	}
 	rootCmd.AddCommand(operationGroupAPIKeysCmd)
 
+	operationGroupRegionsCmd, err := makeOperationGroupRegionsCmd()
+	if err != nil {
+		return nil, err
+	}
+	rootCmd.AddCommand(operationGroupRegionsCmd)
+
 	operationGroupPlansCmd, err := makeOperationGroupPlansCmd()
 	if err != nil {
 		return nil, err
@@ -192,6 +198,24 @@ func MakeRootCmd(rootCmd *cobra.Command) (*cobra.Command, error) {
 		return nil, err
 	}
 	rootCmd.AddCommand(operationGroupVolumeCmd)
+
+	operationGroupTeamsCmd, err := makeOperationGroupTeamsCmd()
+	if err != nil {
+		return nil, err
+	}
+	rootCmd.AddCommand(operationGroupTeamsCmd)
+
+	operationGroupIPsCmd, err := makeOperationGroupIPsCmd()
+	if err != nil {
+		return nil, err
+	}
+	rootCmd.AddCommand(operationGroupIPsCmd)
+
+	operationGroupOperatingSystemsCmd, err := makeOperationGroupOperatingSystemsCmd()
+	if err != nil {
+		return nil, err
+	}
+	rootCmd.AddCommand(operationGroupOperatingSystemsCmd)
 
 	// add cobra completion
 	rootCmd.AddCommand(makeGenCompletionCmd())

--- a/cli/interactive_form.go
+++ b/cli/interactive_form.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// canPromptInteractively reports whether a command may fall back to an
+// interactive prompt for missing required input: stdin must be a TTY and
+// the user must not have asked for fail-fast behavior via --no-input.
+// Mirrors the gating used by resolveProjectFlag.
+func canPromptInteractively(cmd *cobra.Command) bool {
+	noInput, _ := cmd.Flags().GetBool("no-input")
+	return !noInput && isInteractive()
+}
+
+// requiredFlagError is the fail-fast counterpart of the interactive
+// prompts, shown when input is missing and prompting is not possible.
+func requiredFlagError(flag string) error {
+	return fmt.Errorf("--%s is required (pass --%s or run interactively without --no-input)", flag, flag)
+}

--- a/cli/ips.go
+++ b/cli/ips.go
@@ -142,8 +142,18 @@ func runIPsList(cmd *cobra.Command, _ []string) error {
 	}
 
 	rows := make([]renderer.ResponseData, 0, len(resp.IPAddresses.Data))
-	for i := range resp.IPAddresses.Data {
-		rows = append(rows, ipToRow(&resp.IPAddresses.Data[i]))
+	for resp != nil && resp.IPAddresses != nil {
+		for i := range resp.IPAddresses.Data {
+			rows = append(rows, ipToRow(&resp.IPAddresses.Data[i]))
+		}
+		if resp.Next == nil {
+			break
+		}
+		resp, err = resp.Next()
+		if err != nil {
+			utils.PrintError(err)
+			return nil
+		}
 	}
 	renderer.Render(rows)
 	return nil

--- a/cli/ips.go
+++ b/cli/ips.go
@@ -1,0 +1,228 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
+	"github.com/latitudesh/lsh/cmd/lsh"
+	"github.com/latitudesh/lsh/internal/output/table"
+	"github.com/latitudesh/lsh/internal/renderer"
+	"github.com/latitudesh/lsh/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+func makeOperationGroupIPsCmd() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:   "ips",
+		Short: "List and inspect IP addresses",
+	}
+
+	listCmd, err := makeOperationIPsListCmd()
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(listCmd)
+
+	getCmd, err := makeOperationIPsGetCmd()
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(getCmd)
+
+	return cmd, nil
+}
+
+func makeOperationIPsListCmd() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List IP addresses scoped to a project",
+		Example: `  lsh ips list --project=my-project
+  lsh ips list --all-projects
+  lsh ips list --project=my-project --family=IPv4`,
+		Args:         cobra.NoArgs,
+		RunE:         runIPsList,
+		SilenceUsage: true,
+	}
+
+	cmd.Flags().String("project", "", "Project ID or slug to scope by")
+	cmd.Flags().Bool("all-projects", false, "List IPs across every project you have access to")
+	cmd.Flags().String("server", "", "Filter by server ID")
+	cmd.Flags().String("family", "", "Filter by family: IPv4 or IPv6")
+	cmd.Flags().String("type", "", "Filter by type: public or private")
+	cmd.Flags().String("location", "", "Filter by site slug")
+
+	return cmd, nil
+}
+
+func makeOperationIPsGetCmd() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:          "get <ip-id>",
+		Short:        "Retrieve a single IP address by ID",
+		Example:      `  lsh ips get ip_xxx`,
+		Args:         cobra.ExactArgs(1),
+		RunE:         runIPGet,
+		SilenceUsage: true,
+	}
+	return cmd, nil
+}
+
+type ipRow struct {
+	ID       string `json:"id,omitempty"`
+	Address  string `json:"address,omitempty"`
+	Family   string `json:"family,omitempty"`
+	Type     string `json:"type,omitempty"`
+	Project  string `json:"project,omitempty"`
+	Region   string `json:"region,omitempty"`
+	Assigned string `json:"assigned_to,omitempty"`
+}
+
+func (i ipRow) TableRow() table.Row {
+	return table.Row{
+		"id":       {Value: i.ID, Label: "ID"},
+		"address":  {Value: i.Address, Label: "Address"},
+		"family":   {Value: i.Family, Label: "Family"},
+		"type":     {Value: i.Type, Label: "Type"},
+		"project":  {Value: i.Project, Label: "Project"},
+		"region":   {Value: i.Region, Label: "Region"},
+		"assigned": {Value: i.Assigned, Label: "Assigned To"},
+	}
+}
+
+func runIPsList(cmd *cobra.Command, _ []string) error {
+	project, _ := cmd.Flags().GetString("project")
+	server, _ := cmd.Flags().GetString("server")
+	familyStr, _ := cmd.Flags().GetString("family")
+	typeStr, _ := cmd.Flags().GetString("type")
+	location, _ := cmd.Flags().GetString("location")
+
+	req := operations.GetIpsRequest{}
+	if project != "" {
+		req.FilterProject = &project
+	}
+	if server != "" {
+		req.FilterServer = &server
+	}
+	if location != "" {
+		req.FilterLocation = &location
+	}
+	if familyStr != "" {
+		fam, err := parseIPFamily(familyStr)
+		if err != nil {
+			utils.PrintError(err)
+			return nil
+		}
+		req.FilterFamily = &fam
+	}
+	if typeStr != "" {
+		t, err := parseIPType(typeStr)
+		if err != nil {
+			utils.PrintError(err)
+			return nil
+		}
+		req.FilterType = &t
+	}
+
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip sending request.")
+		return nil
+	}
+
+	client := lsh.NewClient()
+	ctx := context.Background()
+
+	resp, err := client.IPAddresses.List(ctx, req)
+	if err != nil {
+		utils.PrintError(err)
+		return nil
+	}
+	if resp == nil || resp.IPAddresses == nil {
+		renderer.Render(nil)
+		return nil
+	}
+
+	rows := make([]renderer.ResponseData, 0, len(resp.IPAddresses.Data))
+	for i := range resp.IPAddresses.Data {
+		rows = append(rows, ipToRow(&resp.IPAddresses.Data[i]))
+	}
+	renderer.Render(rows)
+	return nil
+}
+
+func runIPGet(_ *cobra.Command, args []string) error {
+	ipID := args[0]
+
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip sending request.")
+		return nil
+	}
+
+	client := lsh.NewClient()
+	ctx := context.Background()
+
+	resp, err := client.IPAddresses.Get(ctx, ipID, nil)
+	if err != nil {
+		utils.PrintError(err)
+		return nil
+	}
+	if resp == nil || resp.IPAddress == nil {
+		renderer.Render(nil)
+		return nil
+	}
+	renderer.Render([]renderer.ResponseData{ipToRow(resp.IPAddress)})
+	return nil
+}
+
+func parseIPFamily(s string) (operations.FilterFamily, error) {
+	switch s {
+	case "IPv4", "ipv4", "v4":
+		return operations.FilterFamilyIPv4, nil
+	case "IPv6", "ipv6", "v6":
+		return operations.FilterFamilyIPv6, nil
+	default:
+		return "", &invalidEnumError{field: "family", value: s, allowed: "IPv4, IPv6"}
+	}
+}
+
+func parseIPType(s string) (operations.FilterType, error) {
+	switch s {
+	case "public":
+		return operations.FilterTypePublic, nil
+	case "private":
+		return operations.FilterTypePrivate, nil
+	default:
+		return "", &invalidEnumError{field: "type", value: s, allowed: "public, private"}
+	}
+}
+
+func ipToRow(ip *components.IPAddress) ipRow {
+	row := ipRow{}
+	if ip == nil {
+		return row
+	}
+	if ip.ID != nil {
+		row.ID = *ip.ID
+	}
+	if ip.Attributes == nil {
+		return row
+	}
+	if ip.Attributes.Address != nil {
+		row.Address = *ip.Attributes.Address
+	}
+	if ip.Attributes.Family != nil {
+		row.Family = string(*ip.Attributes.Family)
+	}
+	if ip.Attributes.Type != nil {
+		row.Type = string(*ip.Attributes.Type)
+	}
+	if ip.Attributes.Project != nil && ip.Attributes.Project.Name != nil {
+		row.Project = *ip.Attributes.Project.Name
+	}
+	if ip.Attributes.Region != nil && ip.Attributes.Region.Name != nil {
+		row.Region = *ip.Attributes.Region.Name
+	}
+	if ip.Attributes.Assignment != nil && ip.Attributes.Assignment.Hostname != nil {
+		row.Assigned = *ip.Attributes.Assignment.Hostname
+	}
+	return row
+}

--- a/cli/ips.go
+++ b/cli/ips.go
@@ -2,12 +2,14 @@ package cli
 
 import (
 	"context"
+	"strings"
 
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
 	"github.com/latitudesh/lsh/cmd/lsh"
 	"github.com/latitudesh/lsh/internal/output/table"
 	"github.com/latitudesh/lsh/internal/renderer"
+	"github.com/latitudesh/lsh/internal/tui"
 	"github.com/latitudesh/lsh/internal/utils"
 	"github.com/spf13/cobra"
 )
@@ -46,6 +48,9 @@ func makeOperationIPsListCmd() (*cobra.Command, error) {
 	}
 
 	cmd.Flags().String("project", "", "Project ID or slug to scope by")
+	// all-projects is consumed by the root resolveProjectFlag hook
+	// (project_flag.go): when set, the --project requirement is skipped and
+	// FilterProject stays empty, so the API returns IPs from every project.
 	cmd.Flags().Bool("all-projects", false, "List IPs across every project you have access to")
 	cmd.Flags().String("server", "", "Filter by server ID")
 	cmd.Flags().String("family", "", "Filter by family: IPv4 or IPv6")
@@ -96,7 +101,7 @@ func runIPsList(cmd *cobra.Command, _ []string) error {
 	typeStr, _ := cmd.Flags().GetString("type")
 	location, _ := cmd.Flags().GetString("location")
 
-	req := operations.GetIpsRequest{}
+	req := operations.GetIpsRequest{PageSize: &listPageSize}
 	if project != "" {
 		req.FilterProject = &project
 	}
@@ -131,12 +136,17 @@ func runIPsList(cmd *cobra.Command, _ []string) error {
 	client := lsh.NewClient()
 	ctx := context.Background()
 
+	stopSpinner := tui.StartFetchSpinner("Fetching IPs…")
+	defer stopSpinner()
+
 	resp, err := client.IPAddresses.List(ctx, req)
 	if err != nil {
+		stopSpinner()
 		utils.PrintError(err)
 		return nil
 	}
 	if resp == nil || resp.IPAddresses == nil {
+		stopSpinner()
 		renderer.Render(nil)
 		return nil
 	}
@@ -151,10 +161,12 @@ func runIPsList(cmd *cobra.Command, _ []string) error {
 		}
 		resp, err = resp.Next()
 		if err != nil {
+			stopSpinner()
 			utils.PrintError(err)
 			return nil
 		}
 	}
+	stopSpinner()
 	renderer.Render(rows)
 	return nil
 }
@@ -175,11 +187,11 @@ func runIPGet(_ *cobra.Command, args []string) error {
 		utils.PrintError(err)
 		return nil
 	}
-	if resp == nil || resp.IPAddress == nil {
+	if resp == nil || resp.IPAddress == nil || resp.IPAddress.Data == nil {
 		renderer.Render(nil)
 		return nil
 	}
-	renderer.Render([]renderer.ResponseData{ipToRow(resp.IPAddress)})
+	renderer.Render([]renderer.ResponseData{ipToRow(resp.IPAddress.Data)})
 	return nil
 }
 
@@ -195,7 +207,7 @@ func parseIPFamily(s string) (operations.FilterFamily, error) {
 }
 
 func parseIPType(s string) (operations.FilterType, error) {
-	switch s {
+	switch strings.ToLower(s) {
 	case "public":
 		return operations.FilterTypePublic, nil
 	case "private":
@@ -205,7 +217,7 @@ func parseIPType(s string) (operations.FilterType, error) {
 	}
 }
 
-func ipToRow(ip *components.IPAddress) ipRow {
+func ipToRow(ip *components.IPAddressData) ipRow {
 	row := ipRow{}
 	if ip == nil {
 		return row

--- a/cli/ips_test.go
+++ b/cli/ips_test.go
@@ -43,8 +43,10 @@ func TestParseIPType(t *testing.T) {
 	}{
 		{in: "public", want: operations.FilterTypePublic},
 		{in: "private", want: operations.FilterTypePrivate},
-		{in: "Public", wantErr: true},
+		{in: "Public", want: operations.FilterTypePublic},
+		{in: "PRIVATE", want: operations.FilterTypePrivate},
 		{in: "elastic", wantErr: true},
+		{in: "", wantErr: true},
 	}
 	for _, tc := range cases {
 		got, err := parseIPType(tc.in)
@@ -70,7 +72,7 @@ func TestIPToRow(t *testing.T) {
 			"assignment": {"server_id": "sv_1", "hostname": "web-01"}
 		}
 	}`
-	ip := &components.IPAddress{}
+	ip := &components.IPAddressData{}
 	if err := json.Unmarshal([]byte(fixture), ip); err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +98,7 @@ func TestIPToRow_NilSafety(t *testing.T) {
 	}
 
 	id := "ip_456"
-	row := ipToRow(&components.IPAddress{ID: &id})
+	row := ipToRow(&components.IPAddressData{ID: &id})
 	if row != (ipRow{ID: "ip_456"}) {
 		t.Errorf("ipToRow without attributes = %+v, want only ID set", row)
 	}

--- a/cli/ips_test.go
+++ b/cli/ips_test.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
+)
+
+func TestParseIPFamily(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    operations.FilterFamily
+		wantErr bool
+	}{
+		{in: "IPv4", want: operations.FilterFamilyIPv4},
+		{in: "ipv4", want: operations.FilterFamilyIPv4},
+		{in: "v4", want: operations.FilterFamilyIPv4},
+		{in: "IPv6", want: operations.FilterFamilyIPv6},
+		{in: "ipv6", want: operations.FilterFamilyIPv6},
+		{in: "v6", want: operations.FilterFamilyIPv6},
+		{in: "ipv5", wantErr: true},
+		{in: "", wantErr: true},
+	}
+	for _, tc := range cases {
+		got, err := parseIPFamily(tc.in)
+		if tc.wantErr != (err != nil) {
+			t.Errorf("parseIPFamily(%q): err = %v, wantErr = %v", tc.in, err, tc.wantErr)
+			continue
+		}
+		if err == nil && got != tc.want {
+			t.Errorf("parseIPFamily(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseIPType(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    operations.FilterType
+		wantErr bool
+	}{
+		{in: "public", want: operations.FilterTypePublic},
+		{in: "private", want: operations.FilterTypePrivate},
+		{in: "Public", wantErr: true},
+		{in: "elastic", wantErr: true},
+	}
+	for _, tc := range cases {
+		got, err := parseIPType(tc.in)
+		if tc.wantErr != (err != nil) {
+			t.Errorf("parseIPType(%q): err = %v, wantErr = %v", tc.in, err, tc.wantErr)
+			continue
+		}
+		if err == nil && got != tc.want {
+			t.Errorf("parseIPType(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestIPToRow(t *testing.T) {
+	const fixture = `{
+		"id": "ip_123",
+		"attributes": {
+			"address": "192.0.2.10",
+			"family": "IPv4",
+			"type": "Public",
+			"project": {"id": "proj_1", "name": "My Project"},
+			"region": {"id": "loc_1", "name": "Sao Paulo"},
+			"assignment": {"server_id": "sv_1", "hostname": "web-01"}
+		}
+	}`
+	ip := &components.IPAddress{}
+	if err := json.Unmarshal([]byte(fixture), ip); err != nil {
+		t.Fatal(err)
+	}
+
+	row := ipToRow(ip)
+	want := ipRow{
+		ID:       "ip_123",
+		Address:  "192.0.2.10",
+		Family:   "IPv4",
+		Type:     "Public",
+		Project:  "My Project",
+		Region:   "Sao Paulo",
+		Assigned: "web-01",
+	}
+	if row != want {
+		t.Errorf("ipToRow = %+v, want %+v", row, want)
+	}
+}
+
+func TestIPToRow_NilSafety(t *testing.T) {
+	if row := ipToRow(nil); row != (ipRow{}) {
+		t.Errorf("ipToRow(nil) = %+v, want zero row", row)
+	}
+
+	id := "ip_456"
+	row := ipToRow(&components.IPAddress{ID: &id})
+	if row != (ipRow{ID: "ip_456"}) {
+		t.Errorf("ipToRow without attributes = %+v, want only ID set", row)
+	}
+}

--- a/cli/operating_systems.go
+++ b/cli/operating_systems.go
@@ -1,0 +1,116 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+	"github.com/latitudesh/lsh/cmd/lsh"
+	"github.com/latitudesh/lsh/internal/output/table"
+	"github.com/latitudesh/lsh/internal/renderer"
+	"github.com/latitudesh/lsh/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+func makeOperationGroupOperatingSystemsCmd() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:     "operating-systems",
+		Aliases: []string{"os"},
+		Short:   "List operating systems available for deployment",
+	}
+
+	listCmd, err := makeOperationOperatingSystemsListCmd()
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(listCmd)
+
+	return cmd, nil
+}
+
+func makeOperationOperatingSystemsListCmd() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:          "list",
+		Short:        "List operating systems that can be installed on Latitude servers",
+		Example:      `  lsh operating-systems list`,
+		Args:         cobra.NoArgs,
+		RunE:         runOperatingSystemsList,
+		SilenceUsage: true,
+	}
+	return cmd, nil
+}
+
+type operatingSystemRow struct {
+	ID      string `json:"id,omitempty"`
+	Slug    string `json:"slug,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Distro  string `json:"distro,omitempty"`
+	Version string `json:"version,omitempty"`
+	User    string `json:"user,omitempty"`
+}
+
+func (o operatingSystemRow) TableRow() table.Row {
+	return table.Row{
+		"id":      {Value: o.ID, Label: "ID"},
+		"slug":    {Value: o.Slug, Label: "Slug"},
+		"name":    {Value: o.Name, Label: "Name"},
+		"distro":  {Value: o.Distro, Label: "Distro"},
+		"version": {Value: o.Version, Label: "Version"},
+		"user":    {Value: o.User, Label: "Default User"},
+	}
+}
+
+func runOperatingSystemsList(_ *cobra.Command, _ []string) error {
+	client := lsh.NewClient()
+	ctx := context.Background()
+
+	resp, err := client.OperatingSystems.ListPlans(ctx, nil, nil)
+	if err != nil {
+		utils.PrintError(err)
+		return nil
+	}
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip rendering.")
+		return nil
+	}
+
+	if resp == nil || resp.OperatingSystems == nil {
+		renderer.Render(nil)
+		return nil
+	}
+
+	rows := make([]renderer.ResponseData, 0, len(resp.OperatingSystems.Data))
+	for i := range resp.OperatingSystems.Data {
+		rows = append(rows, operatingSystemToRow(&resp.OperatingSystems.Data[i]))
+	}
+	renderer.Render(rows)
+	return nil
+}
+
+func operatingSystemToRow(o *components.OperatingSystemData) operatingSystemRow {
+	row := operatingSystemRow{}
+	if o == nil {
+		return row
+	}
+	if o.ID != nil {
+		row.ID = *o.ID
+	}
+	if o.Attributes == nil {
+		return row
+	}
+	if o.Attributes.Slug != nil {
+		row.Slug = *o.Attributes.Slug
+	}
+	if o.Attributes.Name != nil {
+		row.Name = *o.Attributes.Name
+	}
+	if o.Attributes.Distro != nil {
+		row.Distro = *o.Attributes.Distro
+	}
+	if o.Attributes.Version != nil {
+		row.Version = *o.Attributes.Version
+	}
+	if o.Attributes.User != nil {
+		row.User = *o.Attributes.User
+	}
+	return row
+}

--- a/cli/operating_systems.go
+++ b/cli/operating_systems.go
@@ -7,6 +7,7 @@ import (
 	"github.com/latitudesh/lsh/cmd/lsh"
 	"github.com/latitudesh/lsh/internal/output/table"
 	"github.com/latitudesh/lsh/internal/renderer"
+	"github.com/latitudesh/lsh/internal/tui"
 	"github.com/latitudesh/lsh/internal/utils"
 	"github.com/spf13/cobra"
 )
@@ -68,12 +69,17 @@ func runOperatingSystemsList(_ *cobra.Command, _ []string) error {
 	client := lsh.NewClient()
 	ctx := context.Background()
 
-	resp, err := client.OperatingSystems.ListPlans(ctx, nil, nil)
+	stopSpinner := tui.StartFetchSpinner("Fetching operating systems…")
+	defer stopSpinner()
+
+	resp, err := client.OperatingSystems.ListPlans(ctx, &listPageSize, nil)
 	if err != nil {
+		stopSpinner()
 		utils.PrintError(err)
 		return nil
 	}
 	if resp == nil || resp.OperatingSystems == nil {
+		stopSpinner()
 		renderer.Render(nil)
 		return nil
 	}
@@ -88,10 +94,12 @@ func runOperatingSystemsList(_ *cobra.Command, _ []string) error {
 		}
 		resp, err = resp.Next()
 		if err != nil {
+			stopSpinner()
 			utils.PrintError(err)
 			return nil
 		}
 	}
+	stopSpinner()
 	renderer.Render(rows)
 	return nil
 }

--- a/cli/operating_systems.go
+++ b/cli/operating_systems.go
@@ -60,6 +60,11 @@ func (o operatingSystemRow) TableRow() table.Row {
 }
 
 func runOperatingSystemsList(_ *cobra.Command, _ []string) error {
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip sending request.")
+		return nil
+	}
+
 	client := lsh.NewClient()
 	ctx := context.Background()
 
@@ -68,19 +73,24 @@ func runOperatingSystemsList(_ *cobra.Command, _ []string) error {
 		utils.PrintError(err)
 		return nil
 	}
-	if lsh.DryRun {
-		lsh.LogDebugf("dry-run flag specified. Skip rendering.")
-		return nil
-	}
-
 	if resp == nil || resp.OperatingSystems == nil {
 		renderer.Render(nil)
 		return nil
 	}
 
 	rows := make([]renderer.ResponseData, 0, len(resp.OperatingSystems.Data))
-	for i := range resp.OperatingSystems.Data {
-		rows = append(rows, operatingSystemToRow(&resp.OperatingSystems.Data[i]))
+	for resp != nil && resp.OperatingSystems != nil {
+		for i := range resp.OperatingSystems.Data {
+			rows = append(rows, operatingSystemToRow(&resp.OperatingSystems.Data[i]))
+		}
+		if resp.Next == nil {
+			break
+		}
+		resp, err = resp.Next()
+		if err != nil {
+			utils.PrintError(err)
+			return nil
+		}
 	}
 	renderer.Render(rows)
 	return nil

--- a/cli/operating_systems_test.go
+++ b/cli/operating_systems_test.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+)
+
+func TestOperatingSystemToRow(t *testing.T) {
+	const fixture = `{
+		"id": "os_123",
+		"attributes": {
+			"name": "Ubuntu 24.04",
+			"slug": "ubuntu_24_04_x64_lts",
+			"distro": "ubuntu",
+			"version": "24.04",
+			"user": "ubuntu"
+		}
+	}`
+	os := &components.OperatingSystemData{}
+	if err := json.Unmarshal([]byte(fixture), os); err != nil {
+		t.Fatal(err)
+	}
+
+	row := operatingSystemToRow(os)
+	want := operatingSystemRow{
+		ID:      "os_123",
+		Slug:    "ubuntu_24_04_x64_lts",
+		Name:    "Ubuntu 24.04",
+		Distro:  "ubuntu",
+		Version: "24.04",
+		User:    "ubuntu",
+	}
+	if row != want {
+		t.Errorf("operatingSystemToRow = %+v, want %+v", row, want)
+	}
+}
+
+func TestOperatingSystemToRow_NilSafety(t *testing.T) {
+	if row := operatingSystemToRow(nil); row != (operatingSystemRow{}) {
+		t.Errorf("operatingSystemToRow(nil) = %+v, want zero row", row)
+	}
+
+	id := "os_456"
+	row := operatingSystemToRow(&components.OperatingSystemData{ID: &id})
+	if row != (operatingSystemRow{ID: "os_456"}) {
+		t.Errorf("operatingSystemToRow without attributes = %+v, want only ID set", row)
+	}
+}

--- a/cli/regions.go
+++ b/cli/regions.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+	"github.com/latitudesh/lsh/cmd/lsh"
+	"github.com/latitudesh/lsh/internal/output/table"
+	"github.com/latitudesh/lsh/internal/renderer"
+	"github.com/latitudesh/lsh/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+func makeOperationGroupRegionsCmd() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:   "regions",
+		Short: "List Latitude regions",
+	}
+
+	listCmd, err := makeOperationRegionsListCmd()
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(listCmd)
+
+	return cmd, nil
+}
+
+func makeOperationRegionsListCmd() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:          "list",
+		Short:        "List every Latitude region available to your account",
+		Example:      `  lsh regions list`,
+		Args:         cobra.NoArgs,
+		RunE:         runRegionsList,
+		SilenceUsage: true,
+	}
+	return cmd, nil
+}
+
+// regionRow is the renderer-friendly projection of a region. It carries
+// both JSON tags (used when `-o json` is set) and a TableRow method
+// (used for the default table / interactive output).
+type regionRow struct {
+	ID          string `json:"id,omitempty"`
+	Slug        string `json:"slug,omitempty"`
+	Name        string `json:"name,omitempty"`
+	CountrySlug string `json:"country_slug,omitempty"`
+	CountryName string `json:"country_name,omitempty"`
+}
+
+func (r regionRow) TableRow() table.Row {
+	return table.Row{
+		"id":      {Value: r.ID, Label: "ID"},
+		"slug":    {Value: r.Slug, Label: "Slug"},
+		"name":    {Value: r.Name, Label: "Name"},
+		"country": {Value: r.CountryName, Label: "Country"},
+	}
+}
+
+func runRegionsList(_ *cobra.Command, _ []string) error {
+	client := lsh.NewClient()
+	ctx := context.Background()
+
+	resp, err := client.Regions.Get(ctx, nil, nil)
+	if err != nil {
+		utils.PrintError(err)
+		return nil
+	}
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip rendering.")
+		return nil
+	}
+
+	if resp == nil || resp.Regions == nil {
+		renderer.Render(nil)
+		return nil
+	}
+
+	rows := make([]renderer.ResponseData, 0, len(resp.Regions.Data))
+	for i := range resp.Regions.Data {
+		rows = append(rows, regionsDataToRow(&resp.Regions.Data[i]))
+	}
+	renderer.Render(rows)
+	return nil
+}
+
+func regionsDataToRow(r *components.RegionsData) regionRow {
+	row := regionRow{}
+	if r == nil {
+		return row
+	}
+	if r.ID != nil {
+		row.ID = *r.ID
+	}
+	if r.Attributes == nil {
+		return row
+	}
+	if r.Attributes.Slug != nil {
+		row.Slug = *r.Attributes.Slug
+	}
+	if r.Attributes.Name != nil {
+		row.Name = *r.Attributes.Name
+	}
+	if r.Attributes.Country != nil {
+		if r.Attributes.Country.Slug != nil {
+			row.CountrySlug = *r.Attributes.Country.Slug
+		}
+		if r.Attributes.Country.Name != nil {
+			row.CountryName = *r.Attributes.Country.Name
+		}
+	}
+	return row
+}

--- a/cli/regions.go
+++ b/cli/regions.go
@@ -7,9 +7,16 @@ import (
 	"github.com/latitudesh/lsh/cmd/lsh"
 	"github.com/latitudesh/lsh/internal/output/table"
 	"github.com/latitudesh/lsh/internal/renderer"
+	"github.com/latitudesh/lsh/internal/tui"
 	"github.com/latitudesh/lsh/internal/utils"
 	"github.com/spf13/cobra"
 )
+
+// listPageSize is the page[size] requested by paginated list commands.
+// The API defaults to 20, which turns large listings into long chains of
+// sequential requests; asking for bigger pages keeps the page count (and
+// wall-clock time) down. Next() reuses the size on follow-up pages.
+var listPageSize int64 = 100
 
 func makeOperationGroupRegionsCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
@@ -67,12 +74,17 @@ func runRegionsList(_ *cobra.Command, _ []string) error {
 	client := lsh.NewClient()
 	ctx := context.Background()
 
-	resp, err := client.Regions.Get(ctx, nil, nil)
+	stopSpinner := tui.StartFetchSpinner("Fetching regions…")
+	defer stopSpinner()
+
+	resp, err := client.Regions.Get(ctx, &listPageSize, nil)
 	if err != nil {
+		stopSpinner()
 		utils.PrintError(err)
 		return nil
 	}
 	if resp == nil || resp.Regions == nil {
+		stopSpinner()
 		renderer.Render(nil)
 		return nil
 	}
@@ -87,10 +99,12 @@ func runRegionsList(_ *cobra.Command, _ []string) error {
 		}
 		resp, err = resp.Next()
 		if err != nil {
+			stopSpinner()
 			utils.PrintError(err)
 			return nil
 		}
 	}
+	stopSpinner()
 	renderer.Render(rows)
 	return nil
 }

--- a/cli/regions.go
+++ b/cli/regions.go
@@ -59,6 +59,11 @@ func (r regionRow) TableRow() table.Row {
 }
 
 func runRegionsList(_ *cobra.Command, _ []string) error {
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip sending request.")
+		return nil
+	}
+
 	client := lsh.NewClient()
 	ctx := context.Background()
 
@@ -67,19 +72,24 @@ func runRegionsList(_ *cobra.Command, _ []string) error {
 		utils.PrintError(err)
 		return nil
 	}
-	if lsh.DryRun {
-		lsh.LogDebugf("dry-run flag specified. Skip rendering.")
-		return nil
-	}
-
 	if resp == nil || resp.Regions == nil {
 		renderer.Render(nil)
 		return nil
 	}
 
 	rows := make([]renderer.ResponseData, 0, len(resp.Regions.Data))
-	for i := range resp.Regions.Data {
-		rows = append(rows, regionsDataToRow(&resp.Regions.Data[i]))
+	for resp != nil && resp.Regions != nil {
+		for i := range resp.Regions.Data {
+			rows = append(rows, regionsDataToRow(&resp.Regions.Data[i]))
+		}
+		if resp.Next == nil {
+			break
+		}
+		resp, err = resp.Next()
+		if err != nil {
+			utils.PrintError(err)
+			return nil
+		}
 	}
 	renderer.Render(rows)
 	return nil

--- a/cli/regions_test.go
+++ b/cli/regions_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+)
+
+func TestRegionsDataToRow(t *testing.T) {
+	const fixture = `{
+		"id": "loc_123",
+		"attributes": {
+			"slug": "SAO",
+			"name": "Sao Paulo",
+			"country": {"slug": "BR", "name": "Brazil"}
+		}
+	}`
+	region := &components.RegionsData{}
+	if err := json.Unmarshal([]byte(fixture), region); err != nil {
+		t.Fatal(err)
+	}
+
+	row := regionsDataToRow(region)
+	want := regionRow{ID: "loc_123", Slug: "SAO", Name: "Sao Paulo", CountrySlug: "BR", CountryName: "Brazil"}
+	if row != want {
+		t.Errorf("regionsDataToRow = %+v, want %+v", row, want)
+	}
+}
+
+func TestRegionsDataToRow_NilSafety(t *testing.T) {
+	if row := regionsDataToRow(nil); row != (regionRow{}) {
+		t.Errorf("regionsDataToRow(nil) = %+v, want zero row", row)
+	}
+
+	id := "loc_456"
+	row := regionsDataToRow(&components.RegionsData{ID: &id})
+	if row != (regionRow{ID: "loc_456"}) {
+		t.Errorf("regionsDataToRow without attributes = %+v, want only ID set", row)
+	}
+
+	slug := "NYC"
+	row = regionsDataToRow(&components.RegionsData{
+		Attributes: &components.RegionsAttributes{Slug: &slug},
+	})
+	if row != (regionRow{Slug: "NYC"}) {
+		t.Errorf("regionsDataToRow without country = %+v, want only Slug set", row)
+	}
+}

--- a/cli/teams.go
+++ b/cli/teams.go
@@ -1,17 +1,27 @@
 package cli
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
 	"strings"
 
+	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
 	"github.com/latitudesh/lsh/cmd/lsh"
+	"github.com/latitudesh/lsh/internal/config"
 	"github.com/latitudesh/lsh/internal/output/table"
 	"github.com/latitudesh/lsh/internal/renderer"
+	"github.com/latitudesh/lsh/internal/tui"
 	"github.com/latitudesh/lsh/internal/utils"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func makeOperationGroupTeamsCmd() (*cobra.Command, error) {
@@ -70,28 +80,29 @@ func makeOperationTeamsCreateCmd() (*cobra.Command, error) {
 		SilenceUsage: true,
 	}
 
-	cmd.Flags().String("name", "", "Team name (required)")
+	cmd.Flags().String("name", "", "Team name (prompted interactively when omitted)")
 	cmd.Flags().String("currency", "USD", "Billing currency: USD or BRL")
 	cmd.Flags().String("address", "", "Billing address")
 	cmd.Flags().String("referred-code", "", "Referral code (first team only)")
-	_ = cmd.MarkFlagRequired("name")
 
 	return cmd, nil
 }
 
 func makeOperationTeamsUpdateCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
-		Use:   "update <team-id>",
+		Use:   "update [team-id]",
 		Short: "Update a team",
 		Example: `  lsh teams update tm_xxx --name="New Name"
-  lsh teams update tm_xxx --currency=BRL`,
-		Args:         cobra.ExactArgs(1),
+  lsh teams update tm_xxx --address="Rua X, 100"
+  lsh teams update   # pick the team and fields interactively`,
+		Args:         cobra.MaximumNArgs(1),
 		RunE:         runTeamsUpdate,
 		SilenceUsage: true,
 	}
 
+	// currency is intentionally absent: the API only allows writing it
+	// on team creation (resource marks it writable: :create_action?).
 	cmd.Flags().String("name", "", "New team name")
-	cmd.Flags().String("currency", "", "Billing currency: USD or BRL")
 	cmd.Flags().String("address", "", "Billing address")
 
 	return cmd, nil
@@ -124,10 +135,14 @@ func runTeamsList(_ *cobra.Command, _ []string) error {
 	client := lsh.NewClient()
 	ctx := context.Background()
 
+	stopSpinner := tui.StartFetchSpinner("Fetching teams…")
+	defer stopSpinner()
+
 	// Unlike the other list commands, /user/teams is not paginated:
 	// the SDK's ListTeams takes no page params and its response has no
 	// Next(), so a single call already returns every team.
 	resp, err := client.UserProfile.ListTeams(ctx)
+	stopSpinner()
 	if err != nil {
 		utils.PrintError(err)
 		return nil
@@ -151,6 +166,37 @@ func runTeamsCreate(cmd *cobra.Command, _ []string) error {
 	currency, _ := cmd.Flags().GetString("currency")
 	address, _ := cmd.Flags().GetString("address")
 	referredCode, _ := cmd.Flags().GetString("referred-code")
+
+	// No --name: fall back to an interactive form when possible.
+	if name == "" {
+		if !canPromptInteractively(cmd) {
+			utils.PrintError(requiredFlagError("name"))
+			return nil
+		}
+
+		var err error
+		name, err = tui.RunTextInput("Team name", "My Team")
+		if err != nil || name == "" {
+			utils.PrintError(requiredFlagError("name"))
+			return nil
+		}
+		if !cmd.Flags().Changed("currency") {
+			currency, err = tui.RunList("Billing currency",
+				[]string{"USD", "BRL"},
+				[]string{"US Dollar", "Brazilian Real"})
+			if err != nil {
+				utils.PrintError(err)
+				return nil
+			}
+		}
+		if address == "" {
+			address, err = tui.RunTextInput("Billing address (enter to skip)", "")
+			if err != nil {
+				utils.PrintError(err)
+				return nil
+			}
+		}
+	}
 
 	cur, err := parsePostTeamCurrency(currency)
 	if err != nil {
@@ -196,14 +242,57 @@ func runTeamsCreate(cmd *cobra.Command, _ []string) error {
 }
 
 func runTeamsUpdate(cmd *cobra.Command, args []string) error {
-	teamID := args[0]
 	name, _ := cmd.Flags().GetString("name")
-	currency, _ := cmd.Flags().GetString("currency")
 	address, _ := cmd.Flags().GetString("address")
 
-	if name == "" && currency == "" && address == "" {
-		utils.PrintError(errors.New("nothing to update: pass at least one of --name, --currency or --address"))
-		return nil
+	// The API only updates the team the token belongs to (auth tokens are
+	// team-scoped; other ids return 404), so the team is resolved from the
+	// active profile instead of prompting for a choice.
+	currentID, currentLabel := currentTeamFromProfile(cmd)
+
+	var teamID string
+	if len(args) > 0 {
+		teamID = args[0]
+		if currentID != "" && teamID != currentID {
+			utils.PrintError(teamMismatchError(currentID, teamID))
+			return nil
+		}
+	} else {
+		if currentID == "" {
+			utils.PrintError(errors.New("team id argument is required (lsh teams update <team-id>)"))
+			return nil
+		}
+		teamID = currentID
+		if currentLabel != "" {
+			fmt.Fprintf(os.Stdout, "Updating team %s (%s)\n", currentLabel, teamID)
+			fmt.Fprintln(os.Stdout, tui.HelpStyle.Render("to update a different team, switch with `lsh profile use <profile>` or run `lsh login`"))
+		}
+	}
+
+	// No flags: fall back to an interactive form when possible, where
+	// pressing enter on an empty field keeps the current value.
+	if name == "" && address == "" {
+		if !canPromptInteractively(cmd) {
+			utils.PrintError(errors.New("nothing to update: pass at least one of --name or --address"))
+			return nil
+		}
+
+		var err error
+		name, err = tui.RunTextInput("New name (enter to keep current)", "")
+		if err != nil {
+			utils.PrintError(err)
+			return nil
+		}
+		address, err = tui.RunTextInput("New billing address (enter to keep current)", "")
+		if err != nil {
+			utils.PrintError(err)
+			return nil
+		}
+
+		if name == "" && address == "" {
+			utils.PrintError(errors.New("nothing to update: every field was left unchanged"))
+			return nil
+		}
 	}
 
 	attrs := &operations.PatchCurrentTeamTeamsAttributes{}
@@ -212,14 +301,6 @@ func runTeamsUpdate(cmd *cobra.Command, args []string) error {
 	}
 	if address != "" {
 		attrs.Address = &address
-	}
-	if currency != "" {
-		cur, err := parsePatchTeamCurrency(currency)
-		if err != nil {
-			utils.PrintError(err)
-			return nil
-		}
-		attrs.Currency = &cur
 	}
 
 	body := operations.PatchCurrentTeamTeamsRequestBody{
@@ -235,7 +316,16 @@ func runTeamsUpdate(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	client := lsh.NewClient()
+	// The SDK injects `"currency":"USD"` into every team PATCH because the
+	// published spec declares a default for it, but the API only allows
+	// writing currency on create — every update would 400 with
+	// "unwritable_attribute". Strip it from the wire until the spec drops
+	// currency from the PATCH body and the SDK is regenerated.
+	httpClient := &http.Client{Transport: stripTeamPatchCurrency{base: http.DefaultTransport}}
+	client := latitudeshgosdk.New(
+		latitudeshgosdk.WithSecurity(viper.GetString("Authorization")),
+		latitudeshgosdk.WithClient(httpClient),
+	)
 	ctx := context.Background()
 
 	resp, err := client.Teams.Update(ctx, teamID, body)
@@ -247,8 +337,117 @@ func runTeamsUpdate(cmd *cobra.Command, args []string) error {
 		renderer.Render(nil)
 		return nil
 	}
+	refreshProfileTeam(cmd, resp.Object.Data)
 	renderer.Render([]renderer.ResponseData{teamToRow(resp.Object.Data)})
 	return nil
+}
+
+// teamMismatchError explains why a team other than the session's cannot be
+// updated, with the shortest path to fix it: switch profiles when one
+// exists for the target team, log in when the team is real but has no
+// profile, or flag a likely typo when the id is not among the user's teams.
+func teamMismatchError(currentID, teamID string) error {
+	base := fmt.Sprintf("tokens are tied to a single team: this session can only update %s", currentID)
+
+	if profileName := profileNameForTeam(teamID); profileName != "" {
+		return fmt.Errorf("%s; to update %s, switch to it with `lsh profile use %s`", base, teamID, profileName)
+	}
+
+	// No profile for the target: check it is actually one of the user's
+	// teams before suggesting a login — an unknown id is most likely a typo.
+	known, checked := isUserTeam(teamID)
+	if checked && !known {
+		return fmt.Errorf("%s; %s is not one of your teams — check the id with `lsh teams list`", base, teamID)
+	}
+	return fmt.Errorf("%s; to update %s, run `lsh login` and pick that team first", base, teamID)
+}
+
+// isUserTeam reports whether the id belongs to one of the user's teams.
+// checked is false when the listing failed and nothing can be asserted.
+func isUserTeam(teamID string) (known, checked bool) {
+	client := lsh.NewClient()
+	resp, err := client.UserProfile.ListTeams(context.Background())
+	if err != nil || resp == nil || resp.UserTeams == nil {
+		return false, false
+	}
+	for i := range resp.UserTeams.Data {
+		if id := resp.UserTeams.Data[i].ID; id != nil && *id == teamID {
+			return true, true
+		}
+	}
+	return false, true
+}
+
+// profileNameForTeam returns the name of a stored profile bound to the
+// given team id, or "" when none exists. Used to suggest `lsh profile use`
+// instead of a fresh login when the user already has a session for the
+// team they are targeting.
+func profileNameForTeam(teamID string) string {
+	f, err := config.Load()
+	if err != nil {
+		return ""
+	}
+	for _, name := range f.SortedProfileNames() {
+		if f.Profiles[name].TeamID == teamID {
+			return name
+		}
+	}
+	return ""
+}
+
+// refreshProfileTeam syncs the stored profile's team metadata after a
+// successful update, so `profile list` and prompts show the new name
+// instead of the one captured at login time.
+func refreshProfileTeam(cmd *cobra.Command, t *components.Team) {
+	if t == nil || t.ID == nil {
+		return
+	}
+	f, err := config.Load()
+	if err != nil {
+		return
+	}
+	override, _ := cmd.Flags().GetString("profile")
+	name, p, err := f.Resolve(override)
+	if err != nil || p.TeamID != *t.ID || t.Attributes == nil {
+		return
+	}
+
+	changed := false
+	if t.Attributes.Name != nil && *t.Attributes.Name != p.TeamName {
+		p.TeamName = *t.Attributes.Name
+		changed = true
+	}
+	if t.Attributes.Slug != nil && *t.Attributes.Slug != p.TeamSlug {
+		p.TeamSlug = *t.Attributes.Slug
+		changed = true
+	}
+	if !changed {
+		return
+	}
+	f.SetProfile(name, p)
+	if err := config.Save(f); err != nil {
+		lsh.LogDebugf("could not refresh profile team metadata: %v", err)
+	}
+}
+
+// currentTeamFromProfile resolves the team tied to the active profile,
+// returning zero values when no profile/team is configured (e.g. raw
+// token auth without a stored profile).
+func currentTeamFromProfile(cmd *cobra.Command) (id, label string) {
+	f, err := config.Load()
+	if err != nil {
+		return "", ""
+	}
+	override, _ := cmd.Flags().GetString("profile")
+	_, p, err := f.Resolve(override)
+	if err != nil {
+		return "", ""
+	}
+	label = p.TeamName
+	if label == "" {
+		label = p.TeamSlug
+	}
+	return p.TeamID, label
 }
 
 func parsePostTeamCurrency(s string) (operations.PostTeamCurrency, error) {
@@ -262,15 +461,52 @@ func parsePostTeamCurrency(s string) (operations.PostTeamCurrency, error) {
 	}
 }
 
-func parsePatchTeamCurrency(s string) (operations.PatchCurrentTeamTeamsCurrency, error) {
-	switch strings.ToUpper(s) {
-	case "USD":
-		return operations.PatchCurrentTeamTeamsCurrencyUsd, nil
-	case "BRL":
-		return operations.PatchCurrentTeamTeamsCurrencyBrl, nil
-	default:
-		return "", &invalidEnumError{field: "currency", value: s, allowed: "USD, BRL"}
+// stripTeamPatchCurrency removes the unwritable currency attribute that the
+// SDK adds to team PATCH bodies via the spec's default value.
+type stripTeamPatchCurrency struct {
+	base http.RoundTripper
+}
+
+func (t stripTeamPatchCurrency) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method == http.MethodPatch && req.Body != nil {
+		raw, err := io.ReadAll(req.Body)
+		req.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+		if stripped, ok := removeBodyAttribute(raw, "currency"); ok {
+			raw = stripped
+		}
+		req.Body = io.NopCloser(bytes.NewReader(raw))
+		req.ContentLength = int64(len(raw))
 	}
+	return t.base.RoundTrip(req)
+}
+
+// removeBodyAttribute deletes data.attributes.<name> from a JSON:API body,
+// reporting whether the body was rewritten.
+func removeBodyAttribute(raw []byte, name string) ([]byte, bool) {
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, false
+	}
+	data, ok := payload["data"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	attrs, ok := data["attributes"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	if _, present := attrs[name]; !present {
+		return nil, false
+	}
+	delete(attrs, name)
+	rewritten, err := json.Marshal(payload)
+	if err != nil {
+		return nil, false
+	}
+	return rewritten, true
 }
 
 type invalidEnumError struct {

--- a/cli/teams.go
+++ b/cli/teams.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
@@ -115,16 +116,17 @@ func (t teamRow) TableRow() table.Row {
 }
 
 func runTeamsList(_ *cobra.Command, _ []string) error {
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip sending request.")
+		return nil
+	}
+
 	client := lsh.NewClient()
 	ctx := context.Background()
 
 	resp, err := client.UserProfile.ListTeams(ctx)
 	if err != nil {
 		utils.PrintError(err)
-		return nil
-	}
-	if lsh.DryRun {
-		lsh.LogDebugf("dry-run flag specified. Skip rendering.")
 		return nil
 	}
 
@@ -195,6 +197,11 @@ func runTeamsUpdate(cmd *cobra.Command, args []string) error {
 	name, _ := cmd.Flags().GetString("name")
 	currency, _ := cmd.Flags().GetString("currency")
 	address, _ := cmd.Flags().GetString("address")
+
+	if name == "" && currency == "" && address == "" {
+		utils.PrintError(errors.New("nothing to update: pass at least one of --name, --currency or --address"))
+		return nil
+	}
 
 	attrs := &operations.PatchCurrentTeamTeamsAttributes{}
 	if name != "" {

--- a/cli/teams.go
+++ b/cli/teams.go
@@ -124,6 +124,9 @@ func runTeamsList(_ *cobra.Command, _ []string) error {
 	client := lsh.NewClient()
 	ctx := context.Background()
 
+	// Unlike the other list commands, /user/teams is not paginated:
+	// the SDK's ListTeams takes no page params and its response has no
+	// Next(), so a single call already returns every team.
 	resp, err := client.UserProfile.ListTeams(ctx)
 	if err != nil {
 		utils.PrintError(err)

--- a/cli/teams.go
+++ b/cli/teams.go
@@ -1,0 +1,324 @@
+package cli
+
+import (
+	"context"
+	"strings"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
+	"github.com/latitudesh/lsh/cmd/lsh"
+	"github.com/latitudesh/lsh/internal/output/table"
+	"github.com/latitudesh/lsh/internal/renderer"
+	"github.com/latitudesh/lsh/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+func makeOperationGroupTeamsCmd() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:   "teams",
+		Short: "Manage teams and team members",
+	}
+
+	listCmd, err := makeOperationTeamsListCmd()
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(listCmd)
+
+	createCmd, err := makeOperationTeamsCreateCmd()
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(createCmd)
+
+	updateCmd, err := makeOperationTeamsUpdateCmd()
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(updateCmd)
+
+	membersCmd, err := makeOperationGroupTeamMembersCmd()
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(membersCmd)
+
+	return cmd, nil
+}
+
+func makeOperationTeamsListCmd() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:          "list",
+		Short:        "List every team you belong to",
+		Example:      `  lsh teams list`,
+		Args:         cobra.NoArgs,
+		RunE:         runTeamsList,
+		SilenceUsage: true,
+	}
+	return cmd, nil
+}
+
+func makeOperationTeamsCreateCmd() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new team",
+		Example: `  lsh teams create --name="My Team" --currency=USD
+  lsh teams create --name="BR Team" --currency=BRL --address="Rua X, 100"`,
+		Args:         cobra.NoArgs,
+		RunE:         runTeamsCreate,
+		SilenceUsage: true,
+	}
+
+	cmd.Flags().String("name", "", "Team name (required)")
+	cmd.Flags().String("currency", "USD", "Billing currency: USD or BRL")
+	cmd.Flags().String("address", "", "Billing address")
+	cmd.Flags().String("referred-code", "", "Referral code (first team only)")
+	_ = cmd.MarkFlagRequired("name")
+
+	return cmd, nil
+}
+
+func makeOperationTeamsUpdateCmd() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:   "update <team-id>",
+		Short: "Update a team",
+		Example: `  lsh teams update tm_xxx --name="New Name"
+  lsh teams update tm_xxx --currency=BRL`,
+		Args:         cobra.ExactArgs(1),
+		RunE:         runTeamsUpdate,
+		SilenceUsage: true,
+	}
+
+	cmd.Flags().String("name", "", "New team name")
+	cmd.Flags().String("currency", "", "Billing currency: USD or BRL")
+	cmd.Flags().String("address", "", "Billing address")
+
+	return cmd, nil
+}
+
+type teamRow struct {
+	ID       string `json:"id,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Slug     string `json:"slug,omitempty"`
+	Currency string `json:"currency,omitempty"`
+	Owner    string `json:"owner,omitempty"`
+}
+
+func (t teamRow) TableRow() table.Row {
+	return table.Row{
+		"id":       {Value: t.ID, Label: "ID"},
+		"name":     {Value: t.Name, Label: "Name"},
+		"slug":     {Value: t.Slug, Label: "Slug"},
+		"currency": {Value: t.Currency, Label: "Currency"},
+		"owner":    {Value: t.Owner, Label: "Owner"},
+	}
+}
+
+func runTeamsList(_ *cobra.Command, _ []string) error {
+	client := lsh.NewClient()
+	ctx := context.Background()
+
+	resp, err := client.UserProfile.ListTeams(ctx)
+	if err != nil {
+		utils.PrintError(err)
+		return nil
+	}
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip rendering.")
+		return nil
+	}
+
+	if resp == nil || resp.UserTeams == nil {
+		renderer.Render(nil)
+		return nil
+	}
+
+	rows := make([]renderer.ResponseData, 0, len(resp.UserTeams.Data))
+	for i := range resp.UserTeams.Data {
+		rows = append(rows, userTeamToRow(&resp.UserTeams.Data[i]))
+	}
+	renderer.Render(rows)
+	return nil
+}
+
+func runTeamsCreate(cmd *cobra.Command, _ []string) error {
+	name, _ := cmd.Flags().GetString("name")
+	currency, _ := cmd.Flags().GetString("currency")
+	address, _ := cmd.Flags().GetString("address")
+	referredCode, _ := cmd.Flags().GetString("referred-code")
+
+	cur, err := parsePostTeamCurrency(currency)
+	if err != nil {
+		utils.PrintError(err)
+		return nil
+	}
+
+	body := operations.PostTeamTeamsRequestBody{
+		Data: operations.PostTeamTeamsData{
+			Type: operations.PostTeamTeamsTypeTeams,
+			Attributes: &operations.PostTeamTeamsAttributes{
+				Name:     name,
+				Currency: cur,
+			},
+		},
+	}
+	if address != "" {
+		body.Data.Attributes.Address = &address
+	}
+	if referredCode != "" {
+		body.Data.Attributes.ReferredCode = &referredCode
+	}
+
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip sending request.")
+		return nil
+	}
+
+	client := lsh.NewClient()
+	ctx := context.Background()
+
+	resp, err := client.Teams.Create(ctx, body)
+	if err != nil {
+		utils.PrintError(err)
+		return nil
+	}
+	if resp == nil || resp.Object == nil || resp.Object.Data == nil {
+		renderer.Render(nil)
+		return nil
+	}
+	renderer.Render([]renderer.ResponseData{teamToRow(resp.Object.Data)})
+	return nil
+}
+
+func runTeamsUpdate(cmd *cobra.Command, args []string) error {
+	teamID := args[0]
+	name, _ := cmd.Flags().GetString("name")
+	currency, _ := cmd.Flags().GetString("currency")
+	address, _ := cmd.Flags().GetString("address")
+
+	attrs := &operations.PatchCurrentTeamTeamsAttributes{}
+	if name != "" {
+		attrs.Name = &name
+	}
+	if address != "" {
+		attrs.Address = &address
+	}
+	if currency != "" {
+		cur, err := parsePatchTeamCurrency(currency)
+		if err != nil {
+			utils.PrintError(err)
+			return nil
+		}
+		attrs.Currency = &cur
+	}
+
+	body := operations.PatchCurrentTeamTeamsRequestBody{
+		Data: operations.PatchCurrentTeamTeamsData{
+			ID:         teamID,
+			Type:       operations.PatchCurrentTeamTeamsTypeTeams,
+			Attributes: attrs,
+		},
+	}
+
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip sending request.")
+		return nil
+	}
+
+	client := lsh.NewClient()
+	ctx := context.Background()
+
+	resp, err := client.Teams.Update(ctx, teamID, body)
+	if err != nil {
+		utils.PrintError(err)
+		return nil
+	}
+	if resp == nil || resp.Object == nil || resp.Object.Data == nil {
+		renderer.Render(nil)
+		return nil
+	}
+	renderer.Render([]renderer.ResponseData{teamToRow(resp.Object.Data)})
+	return nil
+}
+
+func parsePostTeamCurrency(s string) (operations.PostTeamCurrency, error) {
+	switch strings.ToUpper(s) {
+	case "USD":
+		return operations.PostTeamCurrencyUsd, nil
+	case "BRL":
+		return operations.PostTeamCurrencyBrl, nil
+	default:
+		return "", &invalidEnumError{field: "currency", value: s, allowed: "USD, BRL"}
+	}
+}
+
+func parsePatchTeamCurrency(s string) (operations.PatchCurrentTeamTeamsCurrency, error) {
+	switch strings.ToUpper(s) {
+	case "USD":
+		return operations.PatchCurrentTeamTeamsCurrencyUsd, nil
+	case "BRL":
+		return operations.PatchCurrentTeamTeamsCurrencyBrl, nil
+	default:
+		return "", &invalidEnumError{field: "currency", value: s, allowed: "USD, BRL"}
+	}
+}
+
+type invalidEnumError struct {
+	field, value, allowed string
+}
+
+func (e *invalidEnumError) Error() string {
+	return "invalid value for --" + e.field + ": '" + e.value + "' (allowed: " + e.allowed + ")"
+}
+
+func userTeamToRow(t *components.UserTeam) teamRow {
+	row := teamRow{}
+	if t == nil {
+		return row
+	}
+	if t.ID != nil {
+		row.ID = *t.ID
+	}
+	if t.Attributes == nil {
+		return row
+	}
+	if t.Attributes.Name != nil {
+		row.Name = *t.Attributes.Name
+	}
+	if t.Attributes.Slug != nil {
+		row.Slug = *t.Attributes.Slug
+	}
+	if t.Attributes.Currency != nil {
+		row.Currency = *t.Attributes.Currency
+	}
+	if t.Attributes.Owner != nil && t.Attributes.Owner.Email != nil {
+		row.Owner = *t.Attributes.Owner.Email
+	}
+	return row
+}
+
+func teamToRow(t *components.Team) teamRow {
+	row := teamRow{}
+	if t == nil {
+		return row
+	}
+	if t.ID != nil {
+		row.ID = *t.ID
+	}
+	if t.Attributes == nil {
+		return row
+	}
+	if t.Attributes.Name != nil {
+		row.Name = *t.Attributes.Name
+	}
+	if t.Attributes.Slug != nil {
+		row.Slug = *t.Attributes.Slug
+	}
+	if t.Attributes.Currency != nil {
+		row.Currency = *t.Attributes.Currency
+	}
+	if t.Attributes.Owner != nil && t.Attributes.Owner.Email != nil {
+		row.Owner = *t.Attributes.Owner.Email
+	}
+	return row
+}

--- a/cli/teams_members.go
+++ b/cli/teams_members.go
@@ -2,15 +2,18 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
+	latitudeshgosdk "github.com/latitudesh/latitudesh-go-sdk"
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
 	"github.com/latitudesh/lsh/cmd/lsh"
 	"github.com/latitudesh/lsh/internal/output/table"
 	"github.com/latitudesh/lsh/internal/renderer"
+	"github.com/latitudesh/lsh/internal/tui"
 	"github.com/latitudesh/lsh/internal/utils"
 	"github.com/spf13/cobra"
 )
@@ -65,22 +68,21 @@ func makeOperationTeamMembersAddCmd() (*cobra.Command, error) {
 		SilenceUsage: true,
 	}
 
-	cmd.Flags().String("email", "", "User email (required)")
-	cmd.Flags().String("role", "", "Role: owner, administrator, collaborator or billing (required)")
+	cmd.Flags().String("email", "", "User email (prompted interactively when omitted)")
+	cmd.Flags().String("role", "", "Role: owner, administrator, collaborator or billing (prompted interactively when omitted)")
 	cmd.Flags().String("first-name", "", "User first name")
 	cmd.Flags().String("last-name", "", "User last name")
-	_ = cmd.MarkFlagRequired("email")
-	_ = cmd.MarkFlagRequired("role")
 
 	return cmd, nil
 }
 
 func makeOperationTeamMembersRemoveCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
-		Use:          "remove <user-id>",
-		Short:        "Remove a user from the current team",
-		Example:      `  lsh teams members remove usr_xxx`,
-		Args:         cobra.ExactArgs(1),
+		Use:   "remove [user-id]",
+		Short: "Remove a user from the current team",
+		Example: `  lsh teams members remove usr_xxx
+  lsh teams members remove   # pick the member interactively`,
+		Args:         cobra.MaximumNArgs(1),
 		RunE:         runTeamMembersRemove,
 		SilenceUsage: true,
 	}
@@ -92,7 +94,7 @@ type teamMemberRow struct {
 	LastName   string `json:"last_name,omitempty"`
 	Email      string `json:"email,omitempty"`
 	Role       string `json:"role,omitempty"`
-	MfaEnabled bool   `json:"mfa_enabled,omitempty"`
+	MfaEnabled bool   `json:"mfa_enabled"`
 }
 
 func (m teamMemberRow) TableRow() table.Row {
@@ -118,12 +120,17 @@ func runTeamMembersList(_ *cobra.Command, _ []string) error {
 	client := lsh.NewClient()
 	ctx := context.Background()
 
-	resp, err := client.Teams.Members.GetTeamMembers(ctx, nil, nil)
+	stopSpinner := tui.StartFetchSpinner("Fetching team members…")
+	defer stopSpinner()
+
+	resp, err := client.Teams.Members.GetTeamMembers(ctx, &listPageSize, nil)
 	if err != nil {
+		stopSpinner()
 		utils.PrintError(err)
 		return nil
 	}
 	if resp == nil || resp.TeamMembers == nil {
+		stopSpinner()
 		renderer.Render(nil)
 		return nil
 	}
@@ -138,12 +145,23 @@ func runTeamMembersList(_ *cobra.Command, _ []string) error {
 		}
 		resp, err = resp.Next()
 		if err != nil {
+			stopSpinner()
 			utils.PrintError(err)
 			return nil
 		}
 	}
+	stopSpinner()
 	renderer.Render(rows)
 	return nil
+}
+
+var teamMemberRoleNames = []string{"owner", "administrator", "collaborator", "billing"}
+
+var teamMemberRoleDescriptions = []string{
+	"Full control, including billing and team deletion",
+	"Manage resources and members",
+	"Manage resources",
+	"Billing access only",
 }
 
 func runTeamMembersAdd(cmd *cobra.Command, _ []string) error {
@@ -151,6 +169,51 @@ func runTeamMembersAdd(cmd *cobra.Command, _ []string) error {
 	roleStr, _ := cmd.Flags().GetString("role")
 	firstName, _ := cmd.Flags().GetString("first-name")
 	lastName, _ := cmd.Flags().GetString("last-name")
+
+	// Missing required input: fall back to an interactive form when
+	// possible. A missing email opens the full form (role and optional
+	// names included); a missing role alone only prompts the role.
+	if email == "" || roleStr == "" {
+		if !canPromptInteractively(cmd) {
+			missing := "email"
+			if email != "" {
+				missing = "role"
+			}
+			utils.PrintError(requiredFlagError(missing))
+			return nil
+		}
+
+		var err error
+		fullForm := email == ""
+		if fullForm {
+			email, err = tui.RunTextInput("Email", "user@example.com")
+			if err != nil || email == "" {
+				utils.PrintError(requiredFlagError("email"))
+				return nil
+			}
+		}
+		if roleStr == "" {
+			roleStr, err = tui.RunList("Role", teamMemberRoleNames, teamMemberRoleDescriptions)
+			if err != nil {
+				utils.PrintError(err)
+				return nil
+			}
+		}
+		if fullForm && firstName == "" {
+			firstName, err = tui.RunTextInput("First name (enter to skip)", "")
+			if err != nil {
+				utils.PrintError(err)
+				return nil
+			}
+		}
+		if fullForm && lastName == "" {
+			lastName, err = tui.RunTextInput("Last name (enter to skip)", "")
+			if err != nil {
+				utils.PrintError(err)
+				return nil
+			}
+		}
+	}
 
 	role, err := parseTeamMemberRole(roleStr)
 	if err != nil {
@@ -197,9 +260,7 @@ func runTeamMembersAdd(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func runTeamMembersRemove(_ *cobra.Command, args []string) error {
-	userID := args[0]
-
+func runTeamMembersRemove(cmd *cobra.Command, args []string) error {
 	if lsh.DryRun {
 		lsh.LogDebugf("dry-run flag specified. Skip sending request.")
 		return nil
@@ -208,6 +269,33 @@ func runTeamMembersRemove(_ *cobra.Command, args []string) error {
 	client := lsh.NewClient()
 	ctx := context.Background()
 
+	var userID string
+	if len(args) > 0 {
+		userID = args[0]
+	} else {
+		// No argument: pick the member interactively when possible.
+		if !canPromptInteractively(cmd) {
+			utils.PrintError(errors.New("user id argument is required (lsh teams members remove <user-id>, or run interactively without --no-input)"))
+			return nil
+		}
+
+		selected, err := selectTeamMember(ctx, client)
+		if err != nil {
+			utils.PrintError(err)
+			return nil
+		}
+		confirmed, err := tui.RunConfirm(fmt.Sprintf("Remove %s from the team?", selected.email))
+		if err != nil {
+			utils.PrintError(err)
+			return nil
+		}
+		if !confirmed {
+			fmt.Fprintln(os.Stdout, "Aborted.")
+			return nil
+		}
+		userID = selected.id
+	}
+
 	_, err := client.TeamMembers.Delete(ctx, userID)
 	if err != nil {
 		utils.PrintError(err)
@@ -215,6 +303,64 @@ func runTeamMembersRemove(_ *cobra.Command, args []string) error {
 	}
 	fmt.Fprintf(os.Stdout, "✅ Team member %s removed successfully\n", userID)
 	return nil
+}
+
+type teamMemberChoice struct {
+	id    string
+	email string
+}
+
+// selectTeamMember lists the current team's members and lets the user pick
+// one, returning its id. Emails identify the choice since the list selector
+// returns the selected label.
+func selectTeamMember(ctx context.Context, client *latitudeshgosdk.Latitudesh) (teamMemberChoice, error) {
+	stopSpinner := tui.StartFetchSpinner("Fetching team members…")
+	defer stopSpinner()
+
+	resp, err := client.Teams.Members.GetTeamMembers(ctx, &listPageSize, nil)
+	if err != nil {
+		return teamMemberChoice{}, err
+	}
+
+	byEmail := make(map[string]teamMemberChoice)
+	var emails, descriptions []string
+	for resp != nil && resp.TeamMembers != nil {
+		for i := range resp.TeamMembers.Data {
+			m := &resp.TeamMembers.Data[i]
+			if m.ID == nil || m.Attributes == nil || m.Attributes.Email == nil {
+				continue
+			}
+			email := *m.Attributes.Email
+			if _, dup := byEmail[email]; dup {
+				continue
+			}
+			byEmail[email] = teamMemberChoice{id: *m.ID, email: email}
+			emails = append(emails, email)
+			role := ""
+			if m.Attributes.Role != nil && m.Attributes.Role.Name != nil {
+				role = *m.Attributes.Role.Name
+			}
+			descriptions = append(descriptions, role)
+		}
+		if resp.Next == nil {
+			break
+		}
+		resp, err = resp.Next()
+		if err != nil {
+			return teamMemberChoice{}, err
+		}
+	}
+	stopSpinner()
+
+	if len(emails) == 0 {
+		return teamMemberChoice{}, errors.New("no team members found")
+	}
+
+	choice, err := tui.RunList("Select the member to remove", emails, descriptions)
+	if err != nil {
+		return teamMemberChoice{}, err
+	}
+	return byEmail[choice], nil
 }
 
 func parseTeamMemberRole(s string) (operations.PostTeamMembersRole, error) {

--- a/cli/teams_members.go
+++ b/cli/teams_members.go
@@ -1,0 +1,274 @@
+package cli
+
+import (
+	"context"
+	"strings"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
+	"github.com/latitudesh/lsh/cmd/lsh"
+	"github.com/latitudesh/lsh/internal/output/table"
+	"github.com/latitudesh/lsh/internal/renderer"
+	"github.com/latitudesh/lsh/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+func makeOperationGroupTeamMembersCmd() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:   "members",
+		Short: "Manage members of the current team",
+	}
+
+	listCmd, err := makeOperationTeamMembersListCmd()
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(listCmd)
+
+	addCmd, err := makeOperationTeamMembersAddCmd()
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(addCmd)
+
+	removeCmd, err := makeOperationTeamMembersRemoveCmd()
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(removeCmd)
+
+	return cmd, nil
+}
+
+func makeOperationTeamMembersListCmd() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:          "list",
+		Short:        "List members of the current team",
+		Example:      `  lsh teams members list`,
+		Args:         cobra.NoArgs,
+		RunE:         runTeamMembersList,
+		SilenceUsage: true,
+	}
+	return cmd, nil
+}
+
+func makeOperationTeamMembersAddCmd() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Invite a user to the current team",
+		Example: `  lsh teams members add --email=user@example.com --role=collaborator
+  lsh teams members add --email=user@example.com --role=administrator --first-name=Jane --last-name=Doe`,
+		Args:         cobra.NoArgs,
+		RunE:         runTeamMembersAdd,
+		SilenceUsage: true,
+	}
+
+	cmd.Flags().String("email", "", "User email (required)")
+	cmd.Flags().String("role", "", "Role: owner, administrator, collaborator or billing (required)")
+	cmd.Flags().String("first-name", "", "User first name")
+	cmd.Flags().String("last-name", "", "User last name")
+	_ = cmd.MarkFlagRequired("email")
+	_ = cmd.MarkFlagRequired("role")
+
+	return cmd, nil
+}
+
+func makeOperationTeamMembersRemoveCmd() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:          "remove <user-id>",
+		Short:        "Remove a user from the current team",
+		Example:      `  lsh teams members remove usr_xxx`,
+		Args:         cobra.ExactArgs(1),
+		RunE:         runTeamMembersRemove,
+		SilenceUsage: true,
+	}
+	return cmd, nil
+}
+
+type teamMemberRow struct {
+	FirstName  string `json:"first_name,omitempty"`
+	LastName   string `json:"last_name,omitempty"`
+	Email      string `json:"email,omitempty"`
+	Role       string `json:"role,omitempty"`
+	MfaEnabled bool   `json:"mfa_enabled,omitempty"`
+}
+
+func (m teamMemberRow) TableRow() table.Row {
+	mfa := "no"
+	if m.MfaEnabled {
+		mfa = "yes"
+	}
+	return table.Row{
+		"email":      {Value: m.Email, Label: "Email"},
+		"first_name": {Value: m.FirstName, Label: "First Name"},
+		"last_name":  {Value: m.LastName, Label: "Last Name"},
+		"role":       {Value: m.Role, Label: "Role"},
+		"mfa":        {Value: mfa, Label: "MFA"},
+	}
+}
+
+func runTeamMembersList(_ *cobra.Command, _ []string) error {
+	client := lsh.NewClient()
+	ctx := context.Background()
+
+	resp, err := client.Teams.Members.GetTeamMembers(ctx, nil, nil)
+	if err != nil {
+		utils.PrintError(err)
+		return nil
+	}
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip rendering.")
+		return nil
+	}
+
+	if resp == nil || resp.TeamMembers == nil {
+		renderer.Render(nil)
+		return nil
+	}
+
+	rows := make([]renderer.ResponseData, 0, len(resp.TeamMembers.Data))
+	for i := range resp.TeamMembers.Data {
+		rows = append(rows, teamMemberToRow(&resp.TeamMembers.Data[i]))
+	}
+	renderer.Render(rows)
+	return nil
+}
+
+func runTeamMembersAdd(cmd *cobra.Command, _ []string) error {
+	email, _ := cmd.Flags().GetString("email")
+	roleStr, _ := cmd.Flags().GetString("role")
+	firstName, _ := cmd.Flags().GetString("first-name")
+	lastName, _ := cmd.Flags().GetString("last-name")
+
+	role, err := parseTeamMemberRole(roleStr)
+	if err != nil {
+		utils.PrintError(err)
+		return nil
+	}
+
+	attrs := &operations.PostTeamMembersTeamMembersAttributes{
+		Email: email,
+		Role:  role,
+	}
+	if firstName != "" {
+		attrs.FirstName = &firstName
+	}
+	if lastName != "" {
+		attrs.LastName = &lastName
+	}
+
+	body := operations.PostTeamMembersTeamMembersRequestBody{
+		Data: operations.PostTeamMembersTeamMembersData{
+			Type:       operations.PostTeamMembersTeamMembersTypeMemberships,
+			Attributes: attrs,
+		},
+	}
+
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip sending request.")
+		return nil
+	}
+
+	client := lsh.NewClient()
+	ctx := context.Background()
+
+	resp, err := client.TeamMembers.PostTeamMembers(ctx, body)
+	if err != nil {
+		utils.PrintError(err)
+		return nil
+	}
+	if resp == nil || resp.Membership == nil || resp.Membership.Data == nil {
+		renderer.Render(nil)
+		return nil
+	}
+	renderer.Render([]renderer.ResponseData{membershipToRow(resp.Membership.Data)})
+	return nil
+}
+
+func runTeamMembersRemove(_ *cobra.Command, args []string) error {
+	userID := args[0]
+
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip sending request.")
+		return nil
+	}
+
+	client := lsh.NewClient()
+	ctx := context.Background()
+
+	_, err := client.TeamMembers.Delete(ctx, userID)
+	if err != nil {
+		utils.PrintError(err)
+		return nil
+	}
+	return nil
+}
+
+func parseTeamMemberRole(s string) (operations.PostTeamMembersRole, error) {
+	switch strings.ToLower(s) {
+	case "owner":
+		return operations.PostTeamMembersRoleOwner, nil
+	case "administrator":
+		return operations.PostTeamMembersRoleAdministrator, nil
+	case "collaborator":
+		return operations.PostTeamMembersRoleCollaborator, nil
+	case "billing":
+		return operations.PostTeamMembersRoleBilling, nil
+	default:
+		return "", &invalidEnumError{
+			field:   "role",
+			value:   s,
+			allowed: "owner, administrator, collaborator, billing",
+		}
+	}
+}
+
+func teamMemberToRow(m *components.TeamMembersData) teamMemberRow {
+	row := teamMemberRow{}
+	if m == nil || m.Attributes == nil {
+		return row
+	}
+	attrs := m.Attributes
+	if attrs.FirstName != nil {
+		row.FirstName = *attrs.FirstName
+	}
+	if attrs.LastName != nil {
+		row.LastName = *attrs.LastName
+	}
+	if attrs.Email != nil {
+		row.Email = *attrs.Email
+	}
+	if attrs.MfaEnabled != nil {
+		row.MfaEnabled = *attrs.MfaEnabled
+	}
+	if attrs.Role != nil && attrs.Role.Name != nil {
+		row.Role = *attrs.Role.Name
+	}
+	return row
+}
+
+func membershipToRow(m *components.MembershipData) teamMemberRow {
+	row := teamMemberRow{}
+	if m == nil {
+		return row
+	}
+	if m.Attributes == nil {
+		return row
+	}
+	if m.Attributes.FirstName != nil {
+		row.FirstName = *m.Attributes.FirstName
+	}
+	if m.Attributes.LastName != nil {
+		row.LastName = *m.Attributes.LastName
+	}
+	if m.Attributes.Email != nil {
+		row.Email = *m.Attributes.Email
+	}
+	if m.Attributes.MfaEnabled != nil {
+		row.MfaEnabled = *m.Attributes.MfaEnabled
+	}
+	if m.Attributes.Role != nil {
+		row.Role = string(*m.Attributes.Role)
+	}
+	return row
+}

--- a/cli/teams_members.go
+++ b/cli/teams_members.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
@@ -108,6 +110,11 @@ func (m teamMemberRow) TableRow() table.Row {
 }
 
 func runTeamMembersList(_ *cobra.Command, _ []string) error {
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip sending request.")
+		return nil
+	}
+
 	client := lsh.NewClient()
 	ctx := context.Background()
 
@@ -116,19 +123,24 @@ func runTeamMembersList(_ *cobra.Command, _ []string) error {
 		utils.PrintError(err)
 		return nil
 	}
-	if lsh.DryRun {
-		lsh.LogDebugf("dry-run flag specified. Skip rendering.")
-		return nil
-	}
-
 	if resp == nil || resp.TeamMembers == nil {
 		renderer.Render(nil)
 		return nil
 	}
 
 	rows := make([]renderer.ResponseData, 0, len(resp.TeamMembers.Data))
-	for i := range resp.TeamMembers.Data {
-		rows = append(rows, teamMemberToRow(&resp.TeamMembers.Data[i]))
+	for resp != nil && resp.TeamMembers != nil {
+		for i := range resp.TeamMembers.Data {
+			rows = append(rows, teamMemberToRow(&resp.TeamMembers.Data[i]))
+		}
+		if resp.Next == nil {
+			break
+		}
+		resp, err = resp.Next()
+		if err != nil {
+			utils.PrintError(err)
+			return nil
+		}
 	}
 	renderer.Render(rows)
 	return nil
@@ -201,6 +213,7 @@ func runTeamMembersRemove(_ *cobra.Command, args []string) error {
 		utils.PrintError(err)
 		return nil
 	}
+	fmt.Fprintf(os.Stdout, "✅ Team member %s removed successfully\n", userID)
 	return nil
 }
 

--- a/cli/teams_members_test.go
+++ b/cli/teams_members_test.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
+)
+
+func TestParseTeamMemberRole(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    operations.PostTeamMembersRole
+		wantErr bool
+	}{
+		{in: "owner", want: operations.PostTeamMembersRoleOwner},
+		{in: "administrator", want: operations.PostTeamMembersRoleAdministrator},
+		{in: "Administrator", want: operations.PostTeamMembersRoleAdministrator},
+		{in: "collaborator", want: operations.PostTeamMembersRoleCollaborator},
+		{in: "billing", want: operations.PostTeamMembersRoleBilling},
+		{in: "BILLING", want: operations.PostTeamMembersRoleBilling},
+		{in: "admin", wantErr: true},
+		{in: "", wantErr: true},
+	}
+	for _, tc := range cases {
+		got, err := parseTeamMemberRole(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parseTeamMemberRole(%q): expected error, got %q", tc.in, got)
+			} else if !strings.Contains(err.Error(), "owner, administrator, collaborator, billing") {
+				t.Errorf("parseTeamMemberRole(%q): error should list allowed values, got %q", tc.in, err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseTeamMemberRole(%q): unexpected error: %v", tc.in, err)
+		} else if got != tc.want {
+			t.Errorf("parseTeamMemberRole(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestTeamMemberToRow(t *testing.T) {
+	const fixture = `{
+		"id": "usr_123",
+		"attributes": {
+			"first_name": "Jane",
+			"last_name": "Doe",
+			"email": "jane@example.com",
+			"mfa_enabled": true,
+			"role": {"name": "administrator"}
+		}
+	}`
+	member := &components.TeamMembersData{}
+	if err := json.Unmarshal([]byte(fixture), member); err != nil {
+		t.Fatal(err)
+	}
+
+	row := teamMemberToRow(member)
+	want := teamMemberRow{FirstName: "Jane", LastName: "Doe", Email: "jane@example.com", Role: "administrator", MfaEnabled: true}
+	if row != want {
+		t.Errorf("teamMemberToRow = %+v, want %+v", row, want)
+	}
+}
+
+func TestTeamMemberToRow_NilSafety(t *testing.T) {
+	if row := teamMemberToRow(nil); row != (teamMemberRow{}) {
+		t.Errorf("teamMemberToRow(nil) = %+v, want zero row", row)
+	}
+	if row := teamMemberToRow(&components.TeamMembersData{}); row != (teamMemberRow{}) {
+		t.Errorf("teamMemberToRow without attributes = %+v, want zero row", row)
+	}
+}
+
+func TestMembershipToRow(t *testing.T) {
+	const fixture = `{
+		"id": "mem_123",
+		"attributes": {
+			"first_name": "John",
+			"last_name": "Smith",
+			"email": "john@example.com",
+			"role": "collaborator",
+			"mfa_enabled": false
+		}
+	}`
+	membership := &components.MembershipData{}
+	if err := json.Unmarshal([]byte(fixture), membership); err != nil {
+		t.Fatal(err)
+	}
+
+	row := membershipToRow(membership)
+	want := teamMemberRow{FirstName: "John", LastName: "Smith", Email: "john@example.com", Role: "collaborator"}
+	if row != want {
+		t.Errorf("membershipToRow = %+v, want %+v", row, want)
+	}
+
+	if got := membershipToRow(nil); got != (teamMemberRow{}) {
+		t.Errorf("membershipToRow(nil) = %+v, want zero row", got)
+	}
+}
+
+func TestTeamMemberRowTableRow_MFA(t *testing.T) {
+	enabled := teamMemberRow{MfaEnabled: true}.TableRow()
+	if enabled["mfa"].Value != "yes" {
+		t.Errorf("MFA enabled: TableRow mfa = %q, want %q", enabled["mfa"].Value, "yes")
+	}
+	disabled := teamMemberRow{}.TableRow()
+	if disabled["mfa"].Value != "no" {
+		t.Errorf("MFA disabled: TableRow mfa = %q, want %q", disabled["mfa"].Value, "no")
+	}
+}

--- a/cli/teams_test.go
+++ b/cli/teams_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/latitudesh/latitudesh-go-sdk/models/components"
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
+	"github.com/spf13/cobra"
 )
 
 func TestParsePostTeamCurrency(t *testing.T) {
@@ -40,25 +41,77 @@ func TestParsePostTeamCurrency(t *testing.T) {
 	}
 }
 
-func TestParsePatchTeamCurrency(t *testing.T) {
-	cases := []struct {
-		in      string
-		want    operations.PatchCurrentTeamTeamsCurrency
-		wantErr bool
-	}{
-		{in: "USD", want: operations.PatchCurrentTeamTeamsCurrencyUsd},
-		{in: "brl", want: operations.PatchCurrentTeamTeamsCurrencyBrl},
-		{in: "GBP", wantErr: true},
+func TestRefreshProfileTeam(t *testing.T) {
+	home := withTempHome(t)
+	writeConfig(t, home, `{
+		"default_profile": "work",
+		"profiles": {
+			"work": {"authorization": "k", "team_id": "team_1", "team_name": "Old Name", "team_slug": "old-name"}
+		}
+	}`)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("profile", "", "")
+
+	id := "team_1"
+	newName := "New Name"
+	newSlug := "new-name"
+	refreshProfileTeam(cmd, &components.Team{
+		ID:         &id,
+		Attributes: &components.TeamAttributes{Name: &newName, Slug: &newSlug},
+	})
+
+	got := readConfig(t, home)
+	if !strings.Contains(got, `"team_name": "New Name"`) && !strings.Contains(got, `"team_name":"New Name"`) {
+		t.Errorf("profile team_name not refreshed, config: %s", got)
 	}
-	for _, tc := range cases {
-		got, err := parsePatchTeamCurrency(tc.in)
-		if tc.wantErr != (err != nil) {
-			t.Errorf("parsePatchTeamCurrency(%q): err = %v, wantErr = %v", tc.in, err, tc.wantErr)
-			continue
-		}
-		if err == nil && got != tc.want {
-			t.Errorf("parsePatchTeamCurrency(%q) = %q, want %q", tc.in, got, tc.want)
-		}
+
+	// A different team id must not touch the stored profile.
+	otherID := "team_2"
+	otherName := "Other"
+	refreshProfileTeam(cmd, &components.Team{ID: &otherID, Attributes: &components.TeamAttributes{Name: &otherName}})
+	got = readConfig(t, home)
+	if strings.Contains(got, "Other") {
+		t.Errorf("profile refreshed for a team it does not belong to: %s", got)
+	}
+}
+
+func TestRemoveBodyAttribute(t *testing.T) {
+	// The SDK injects the spec's default currency into every team PATCH
+	// body; the transport must strip it without touching other fields.
+	name := "New Name"
+	body := operations.PatchCurrentTeamTeamsRequestBody{
+		Data: operations.PatchCurrentTeamTeamsData{
+			ID:         "tm_x",
+			Type:       operations.PatchCurrentTeamTeamsTypeTeams,
+			Attributes: &operations.PatchCurrentTeamTeamsAttributes{Name: &name},
+		},
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"currency"`) {
+		t.Fatalf("expected SDK to inject currency default, got %s", raw)
+	}
+
+	stripped, ok := removeBodyAttribute(raw, "currency")
+	if !ok {
+		t.Fatal("removeBodyAttribute: expected rewrite, got ok=false")
+	}
+	if strings.Contains(string(stripped), `"currency"`) {
+		t.Errorf("currency still present after strip: %s", stripped)
+	}
+	if !strings.Contains(string(stripped), `"name":"New Name"`) {
+		t.Errorf("name was lost during strip: %s", stripped)
+	}
+
+	// Bodies without the attribute are reported as untouched.
+	if _, ok := removeBodyAttribute(stripped, "currency"); ok {
+		t.Error("expected ok=false when attribute is absent")
+	}
+	if _, ok := removeBodyAttribute([]byte("not json"), "currency"); ok {
+		t.Error("expected ok=false for invalid JSON")
 	}
 }
 

--- a/cli/teams_test.go
+++ b/cli/teams_test.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
+)
+
+func TestParsePostTeamCurrency(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    operations.PostTeamCurrency
+		wantErr bool
+	}{
+		{in: "USD", want: operations.PostTeamCurrencyUsd},
+		{in: "usd", want: operations.PostTeamCurrencyUsd},
+		{in: "BRL", want: operations.PostTeamCurrencyBrl},
+		{in: "brl", want: operations.PostTeamCurrencyBrl},
+		{in: "EUR", wantErr: true},
+		{in: "", wantErr: true},
+	}
+	for _, tc := range cases {
+		got, err := parsePostTeamCurrency(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parsePostTeamCurrency(%q): expected error, got %q", tc.in, got)
+			} else if !strings.Contains(err.Error(), "USD, BRL") {
+				t.Errorf("parsePostTeamCurrency(%q): error should list allowed values, got %q", tc.in, err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parsePostTeamCurrency(%q): unexpected error: %v", tc.in, err)
+		} else if got != tc.want {
+			t.Errorf("parsePostTeamCurrency(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParsePatchTeamCurrency(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    operations.PatchCurrentTeamTeamsCurrency
+		wantErr bool
+	}{
+		{in: "USD", want: operations.PatchCurrentTeamTeamsCurrencyUsd},
+		{in: "brl", want: operations.PatchCurrentTeamTeamsCurrencyBrl},
+		{in: "GBP", wantErr: true},
+	}
+	for _, tc := range cases {
+		got, err := parsePatchTeamCurrency(tc.in)
+		if tc.wantErr != (err != nil) {
+			t.Errorf("parsePatchTeamCurrency(%q): err = %v, wantErr = %v", tc.in, err, tc.wantErr)
+			continue
+		}
+		if err == nil && got != tc.want {
+			t.Errorf("parsePatchTeamCurrency(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestUserTeamToRow(t *testing.T) {
+	const fixture = `{
+		"id": "tm_123",
+		"attributes": {
+			"name": "My Team",
+			"slug": "my-team",
+			"currency": "USD",
+			"owner": {"email": "owner@example.com"}
+		}
+	}`
+	team := &components.UserTeam{}
+	if err := json.Unmarshal([]byte(fixture), team); err != nil {
+		t.Fatal(err)
+	}
+
+	row := userTeamToRow(team)
+	want := teamRow{ID: "tm_123", Name: "My Team", Slug: "my-team", Currency: "USD", Owner: "owner@example.com"}
+	if row != want {
+		t.Errorf("userTeamToRow = %+v, want %+v", row, want)
+	}
+}
+
+func TestUserTeamToRow_NilSafety(t *testing.T) {
+	if row := userTeamToRow(nil); row != (teamRow{}) {
+		t.Errorf("userTeamToRow(nil) = %+v, want zero row", row)
+	}
+
+	id := "tm_456"
+	row := userTeamToRow(&components.UserTeam{ID: &id})
+	if row != (teamRow{ID: "tm_456"}) {
+		t.Errorf("userTeamToRow without attributes = %+v, want only ID set", row)
+	}
+}
+
+func TestTeamToRow(t *testing.T) {
+	const fixture = `{
+		"id": "tm_789",
+		"attributes": {
+			"name": "New Team",
+			"slug": "new-team",
+			"currency": "BRL",
+			"owner": {"email": "ceo@example.com"}
+		}
+	}`
+	team := &components.Team{}
+	if err := json.Unmarshal([]byte(fixture), team); err != nil {
+		t.Fatal(err)
+	}
+
+	row := teamToRow(team)
+	want := teamRow{ID: "tm_789", Name: "New Team", Slug: "new-team", Currency: "BRL", Owner: "ceo@example.com"}
+	if row != want {
+		t.Errorf("teamToRow = %+v, want %+v", row, want)
+	}
+
+	if got := teamToRow(nil); got != (teamRow{}) {
+		t.Errorf("teamToRow(nil) = %+v, want zero row", got)
+	}
+}

--- a/cli/volume_delete_operation.go
+++ b/cli/volume_delete_operation.go
@@ -97,7 +97,7 @@ func (o *VolumeDeleteOperation) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Call the API
-	response, err := client.Storage.DeleteStorageVolumes(ctx, volumeID)
+	response, err := client.BlockStorage.DeleteStorageVolumes(ctx, volumeID)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error deleting volume storage: %v\n", err)
 		return err

--- a/cli/volume_get_operation.go
+++ b/cli/volume_get_operation.go
@@ -86,7 +86,7 @@ func (o *VolumeGetOperation) run(cmd *cobra.Command, args []string) error {
 
 	// NOTE: The SDK doesn't seem to have a GetStorageVolume (singular) method yet
 	// For now, use list and filter by ID
-	response, err := client.Storage.GetStorageVolumes(ctx, nil)
+	response, err := client.BlockStorage.GetStorageVolumes(ctx, nil)
 	if err != nil {
 		utils.PrintError(err)
 		return nil

--- a/cli/volume_list_operation.go
+++ b/cli/volume_list_operation.go
@@ -88,7 +88,7 @@ func (o *VolumeListOperation) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Call the API
-	response, err := client.Storage.GetStorageVolumes(ctx, filterProject)
+	response, err := client.BlockStorage.GetStorageVolumes(ctx, filterProject)
 	if err != nil {
 		utils.PrintError(err)
 		return nil

--- a/cli/volume_mount_operation.go
+++ b/cli/volume_mount_operation.go
@@ -507,7 +507,7 @@ func (o *VolumeMountOperation) run(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stdout, "[DEBUG] Fetching volume storage details to get connector_id\n")
 		}
 
-		volumesResponse, err := client.Storage.GetStorageVolumes(ctx, nil)
+		volumesResponse, err := client.BlockStorage.GetStorageVolumes(ctx, nil)
 		if err != nil {
 			printError(fmt.Sprintf("Failed to fetch volume storage details: %v", err))
 			utils.PrintError(err)
@@ -579,7 +579,7 @@ func (o *VolumeMountOperation) run(cmd *cobra.Command, args []string) error {
 	// Call the API to authorize the client NQN and mount
 	// The NQN authorizes this client to access the storage
 	// The subsystem-nqn (connector_id) defines which storage subsystem to connect to
-	response, err := client.Storage.PostStorageVolumesMount(ctx, volumeID, operations.PostStorageVolumesMountRequestBody{
+	response, err := client.BlockStorage.PostStorageVolumesMount(ctx, volumeID, operations.PostStorageVolumesMountRequestBody{
 		Data: operations.PostStorageVolumesMountData{
 			Type: operations.PostStorageVolumesMountTypeVolumes,
 			Attributes: operations.PostStorageVolumesMountAttributes{

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-openapi/strfmt v0.22.0
 	github.com/go-openapi/swag v0.22.7
 	github.com/go-openapi/validate v0.22.6
-	github.com/latitudesh/latitudesh-go-sdk v1.15.0
+	github.com/latitudesh/latitudesh-go-sdk v1.15.1
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/latitudesh/lsh
 
-go 1.24.0
+go 1.25.10
 
 require (
 	github.com/charmbracelet/bubbles v0.21.0
@@ -12,7 +12,7 @@ require (
 	github.com/go-openapi/strfmt v0.22.0
 	github.com/go-openapi/swag v0.22.7
 	github.com/go-openapi/validate v0.22.6
-	github.com/latitudesh/latitudesh-go-sdk v1.9.0
+	github.com/latitudesh/latitudesh-go-sdk v1.15.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,10 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/latitudesh/latitudesh-go-sdk v1.9.0 h1:ruiqf/dGRTDek+29inA2LJ2Ss+iPtxMHNJfJmyyCwNk=
 github.com/latitudesh/latitudesh-go-sdk v1.9.0/go.mod h1:dMRsFr7Y/1RuJRt38fHSt+f2YOtLkdmpXdGiW+VVaOg=
+github.com/latitudesh/latitudesh-go-sdk v1.13.4 h1:hzSSIjkr7rfbQNDJlkVweQc5oemFKNj/4C5x/q6dOo8=
+github.com/latitudesh/latitudesh-go-sdk v1.13.4/go.mod h1:Uso3PR7vjaRxfpAzlDt6LUYLvBdiL4ZZBrYmKm64sp8=
+github.com/latitudesh/latitudesh-go-sdk v1.15.0 h1:/4xo9fasJEZgq4u60IAmsd02pPDexnzFRBkwLXu+8ZI=
+github.com/latitudesh/latitudesh-go-sdk v1.15.0/go.mod h1:Uso3PR7vjaRxfpAzlDt6LUYLvBdiL4ZZBrYmKm64sp8=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/latitudesh/latitudesh-go-sdk v1.13.4 h1:hzSSIjkr7rfbQNDJlkVweQc5oemFK
 github.com/latitudesh/latitudesh-go-sdk v1.13.4/go.mod h1:Uso3PR7vjaRxfpAzlDt6LUYLvBdiL4ZZBrYmKm64sp8=
 github.com/latitudesh/latitudesh-go-sdk v1.15.0 h1:/4xo9fasJEZgq4u60IAmsd02pPDexnzFRBkwLXu+8ZI=
 github.com/latitudesh/latitudesh-go-sdk v1.15.0/go.mod h1:Uso3PR7vjaRxfpAzlDt6LUYLvBdiL4ZZBrYmKm64sp8=
+github.com/latitudesh/latitudesh-go-sdk v1.15.1 h1:aoMLmnqGUT8pw4JKHexHX0Rr9vkMn7pgFaXs4Eed+DQ=
+github.com/latitudesh/latitudesh-go-sdk v1.15.1/go.mod h1:Uso3PR7vjaRxfpAzlDt6LUYLvBdiL4ZZBrYmKm64sp8=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=

--- a/internal/renderer/bubbletea.go
+++ b/internal/renderer/bubbletea.go
@@ -23,6 +23,11 @@ func (btr BubbleTeaRenderer) Render(data []ResponseData) {
 		return
 	}
 
+	if isIPData(data) {
+		renderIPsWithDetails(data)
+		return
+	}
+
 	// Convert ResponseData to Bubble Tea format
 	columns, rows := convertToTableFormat(data)
 
@@ -44,6 +49,38 @@ func isServerData(data []ResponseData) bool {
 	_, hasHostname := firstRow["hostname"]
 	_, hasIPMI := firstRow["ipmi_status"]
 	return hasHostname && hasIPMI
+}
+
+// isIPData checks if the data is IP address data
+func isIPData(data []ResponseData) bool {
+	if len(data) == 0 {
+		return false
+	}
+
+	firstRow := data[0].TableRow()
+	_, hasAddress := firstRow["address"]
+	_, hasFamily := firstRow["family"]
+	return hasAddress && hasFamily
+}
+
+// renderIPsWithDetails renders IPs with enter-to-details support
+func renderIPsWithDetails(data []ResponseData) {
+	columns, rows := convertToTableFormat(data)
+
+	var originals []map[string]string
+	for _, item := range data {
+		row := item.TableRow()
+		fields := make(map[string]string)
+		for _, cell := range row {
+			fields[cell.Label] = fmt.Sprintf("%v", cell.Value)
+		}
+		originals = append(originals, fields)
+	}
+
+	err := tui.RunResourceTable("IP Addresses", "IPs", "IP Details", "Address", columns, rows, originals)
+	if err != nil {
+		fmt.Printf("Error rendering table: %v\n", err)
+	}
 }
 
 // renderServersWithDetails renders servers with details support

--- a/internal/tui/fetch_spinner.go
+++ b/internal/tui/fetch_spinner.go
@@ -1,0 +1,46 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"golang.org/x/term"
+)
+
+var fetchSpinnerFrames = []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
+
+// StartFetchSpinner shows a lightweight spinner on stderr while a command
+// fetches data, so slow (multi-page) listings don't look frozen. It writes
+// to stderr so piped stdout (json/table output) stays clean, and becomes a
+// no-op when stderr is not a terminal (scripts, CI). The returned stop
+// function clears the spinner line and is safe to call more than once.
+func StartFetchSpinner(message string) (stop func()) {
+	if !term.IsTerminal(int(os.Stderr.Fd())) {
+		return func() {}
+	}
+
+	done := make(chan struct{})
+	var once sync.Once
+	go func() {
+		ticker := time.NewTicker(80 * time.Millisecond)
+		defer ticker.Stop()
+		for i := 0; ; i++ {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				frame := fetchSpinnerFrames[i%len(fetchSpinnerFrames)]
+				fmt.Fprintf(os.Stderr, "\r%s %s", frame, message)
+			}
+		}
+	}()
+
+	return func() {
+		once.Do(func() {
+			close(done)
+			fmt.Fprintf(os.Stderr, "\r\033[K")
+		})
+	}
+}

--- a/internal/tui/resource_details.go
+++ b/internal/tui/resource_details.go
@@ -1,0 +1,124 @@
+package tui
+
+import (
+	"sort"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ResourceDetailsModel renders one resource as a label/value sheet, like
+// the server details view but with a caller-provided field order.
+type ResourceDetailsModel struct {
+	title    string
+	fields   map[string]string
+	order    []string
+	quitting bool
+}
+
+func NewResourceDetails(title string, fields map[string]string, order []string) ResourceDetailsModel {
+	return ResourceDetailsModel{
+		title:  title,
+		fields: fields,
+		order:  order,
+	}
+}
+
+func (m ResourceDetailsModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m ResourceDetailsModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "esc", "ctrl+c", "backspace":
+			m.quitting = true
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+func (m ResourceDetailsModel) View() string {
+	if m.quitting {
+		return ""
+	}
+
+	titleStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(PrimaryColor).
+		MarginBottom(1).
+		Padding(0, 1)
+
+	fieldLabelStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(PrimaryColor).
+		Width(20).
+		Align(lipgloss.Right)
+
+	fieldValueStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("255")).
+		Padding(0, 1)
+
+	boxStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(PrimaryColor).
+		Padding(1, 2).
+		MarginTop(1)
+
+	renderField := func(key, value string) string {
+		return lipgloss.JoinHorizontal(
+			lipgloss.Top,
+			fieldLabelStyle.Render(key+":"),
+			fieldValueStyle.Render(value),
+		)
+	}
+
+	var fields []string
+	ordered := make(map[string]bool)
+	for _, key := range m.order {
+		ordered[key] = true
+		if value, exists := m.fields[key]; exists && value != "" {
+			fields = append(fields, renderField(key, value))
+		}
+	}
+
+	// Render remaining fields alphabetically so the output is stable.
+	var remaining []string
+	for key, value := range m.fields {
+		if !ordered[key] && value != "" {
+			remaining = append(remaining, key)
+		}
+	}
+	sort.Strings(remaining)
+	for _, key := range remaining {
+		fields = append(fields, renderField(key, m.fields[key]))
+	}
+
+	content := strings.Join(fields, "\n")
+
+	box := boxStyle.Render(content)
+
+	help := HelpStyle.Render("esc/backspace: back • q: quit")
+
+	return lipgloss.JoinVertical(
+		lipgloss.Left,
+		titleStyle.Render(m.title),
+		box,
+		"\n",
+		help,
+	)
+}
+
+// RunResourceDetails shows the details of a single resource.
+func RunResourceDetails(title string, fields map[string]string, order []string) error {
+	p := tea.NewProgram(
+		NewResourceDetails(title, fields, order),
+		tea.WithAltScreen(),
+	)
+
+	_, err := p.Run()
+	return err
+}

--- a/internal/tui/resource_table.go
+++ b/internal/tui/resource_table.go
@@ -1,0 +1,166 @@
+package tui
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ResourceTableModel generalizes the servers table pattern: an interactive
+// list where enter opens a details view of the selected row.
+type ResourceTableModel struct {
+	table        table.Model
+	totalRecords int
+	title        string
+	noun         string
+	quitting     bool
+	selected     int
+	showDetails  bool
+}
+
+// NewResourceTable creates an interactive table with details navigation.
+func NewResourceTable(title, noun string, columns []table.Column, rows []table.Row) ResourceTableModel {
+	height := len(rows)
+	if height > 25 {
+		height = 25
+	}
+	if height < 10 {
+		height = 10
+	}
+
+	t := table.New(
+		table.WithColumns(columns),
+		table.WithRows(rows),
+		table.WithFocused(true),
+		table.WithHeight(height),
+	)
+
+	s := table.DefaultStyles()
+	s.Header = s.Header.
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(PrimaryColor).
+		BorderBottom(true).
+		Bold(true).
+		Foreground(PrimaryColor)
+
+	s.Selected = selectedRowStyle
+	s.Cell = s.Cell.Padding(0, 1)
+
+	t.SetStyles(s)
+
+	return ResourceTableModel{
+		table:        t,
+		totalRecords: len(rows),
+		title:        title,
+		noun:         noun,
+	}
+}
+
+func (m ResourceTableModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m ResourceTableModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "esc", "ctrl+c":
+			m.quitting = true
+			return m, tea.Quit
+		case "enter":
+			m.selected = m.table.Cursor()
+			m.showDetails = true
+			m.quitting = true
+			return m, tea.Quit
+		}
+	}
+
+	m.table, cmd = m.table.Update(msg)
+	return m, cmd
+}
+
+func (m ResourceTableModel) View() string {
+	if m.quitting {
+		return ""
+	}
+
+	header := ""
+	if m.title != "" {
+		header = TitleStyle.Render(m.title) + "\n\n"
+	}
+
+	tableView := baseTableStyle.Render(m.table.View())
+
+	footer := footerStyle.Render(
+		fmt.Sprintf("Total: %d %s", m.totalRecords, m.noun),
+	)
+
+	help := HelpStyle.Render("↑/↓: navigate • enter: details • q/esc: quit")
+
+	return lipgloss.JoinVertical(
+		lipgloss.Left,
+		header,
+		tableView,
+		"\n",
+		footer,
+		help,
+	)
+}
+
+// SelectedIndex returns the selected index
+func (m ResourceTableModel) SelectedIndex() int {
+	return m.selected
+}
+
+// ShouldShowDetails returns if should show details
+func (m ResourceTableModel) ShouldShowDetails() bool {
+	return m.showDetails
+}
+
+// RunResourceTable runs an interactive table with enter-to-details
+// navigation. detailTitleKey selects which field of the chosen row names
+// the details view (e.g. "Address" → "IP Details: 192.0.2.10"); the
+// details fields follow the table's column order.
+func RunResourceTable(title, noun, detailTitlePrefix, detailTitleKey string, columns []table.Column, rows []table.Row, originals []map[string]string) error {
+	if len(rows) == 0 {
+		fmt.Println(ErrorStyle.Render("\nNo results found.\n"))
+		return nil
+	}
+
+	fieldOrder := make([]string, 0, len(columns))
+	for _, c := range columns {
+		fieldOrder = append(fieldOrder, c.Title)
+	}
+
+	for {
+		p := tea.NewProgram(
+			NewResourceTable(title, noun, columns, rows),
+			tea.WithAltScreen(),
+		)
+
+		m, err := p.Run()
+		if err != nil {
+			return err
+		}
+
+		if model, ok := m.(ResourceTableModel); ok {
+			if model.ShouldShowDetails() && model.SelectedIndex() < len(originals) {
+				selected := originals[model.SelectedIndex()]
+				detailTitle := fmt.Sprintf("%s: %s", detailTitlePrefix, selected[detailTitleKey])
+				if err := RunResourceDetails(detailTitle, selected, fieldOrder); err != nil {
+					return err
+				}
+
+				continue
+			}
+		}
+
+		break
+	}
+
+	return nil
+}

--- a/internal/tui/servers_table.go
+++ b/internal/tui/servers_table.go
@@ -142,7 +142,9 @@ func RunServersTable(title string, columns []table.Column, rows []table.Row, ori
 			if model.ShouldShowDetails() && model.SelectedIndex() < len(originalServers) {
 				selectedServer := originalServers[model.SelectedIndex()]
 				serverTitle := fmt.Sprintf("Server Details: %s", selectedServer["Hostname"])
-				RunServerDetails(serverTitle, selectedServer)
+				if err := RunServerDetails(serverTitle, selectedServer); err != nil {
+					return err
+				}
 
 				continue
 			}

--- a/internal/util/tty.go
+++ b/internal/util/tty.go
@@ -2,15 +2,19 @@
 // command layer and the prompt/auth subpackages.
 package util
 
-import "os"
+import (
+	"os"
+
+	"golang.org/x/term"
+)
 
 // IsTTY reports whether stdin is connected to a terminal.
 // Used to decide whether to run interactive prompts vs. fail with
 // an actionable error in non-interactive contexts (CI, pipes).
+//
+// term.IsTerminal (isatty) is used instead of checking ModeCharDevice:
+// /dev/null is a character device but not a terminal, and prompting
+// against it crashes bubbletea with "could not open a new TTY".
 func IsTTY() bool {
-	info, err := os.Stdin.Stat()
-	if err != nil {
-		return false
-	}
-	return (info.Mode() & os.ModeCharDevice) != 0
+	return term.IsTerminal(int(os.Stdin.Fd()))
 }


### PR DESCRIPTION
## Summary

Extends CLI API coverage with admin and metadata commands (PD-6080): team & member
management plus the regions / IPs / operating-systems catalogs — with interactive
fallbacks for required input and an enter-to-details view on IP listings. Bumps the
Go SDK to `v1.15.1`, which exposes these endpoints and consumes the fixed JSON:API
envelope for `GET /ips/{id}`.

## Commands added

| Group | Subcommands |
|-------|-------------|
| `lsh teams` | `list`, `create`, `update` |
| `lsh teams members` | `list`, `add`, `remove` |
| `lsh regions` | `list` |
| `lsh ips` | `list`, `get <ip-id>` |
| `lsh operating-systems` | `list` (alias `os`) |

- `teams members add --role <name>` takes the human role name (`owner` /
  `administrator` / `collaborator` / `billing`) and resolves it to the SDK enum
  internally, with a clear error on an invalid value.
- `ips list` is project-scoped (`--project`, or `--all-projects`) with `--family`,
  `--type`, `--location`, `--server` filters (case-insensitive enums);
  `ips get <ip-id>` is the single-record drill-down.
- All list commands paginate to exhaustion via the SDK's `Next()` using
  `page[size]=100`, and show a stderr spinner while fetching (TTY only).

## Interactive UX (TTY only — scripts fail fast with actionable errors)

- `teams create`, `teams update` and `teams members add` open a form when required
  flags are omitted; `teams members remove` without an argument lists the team's
  members for selection and asks for confirmation before deleting.
- `ips list` renders an interactive table where **enter** opens a details view of
  the selected IP (same pattern as `servers`), via new reusable
  `ResourceTable`/`ResourceDetails` TUI components.
- With `--no-input` or non-TTY stdin (pipes, CI), every interactive fallback is
  replaced by a fail-fast error naming the missing flag.

## Behavior notes

- `teams update` operates on the team the token belongs to (API tokens are
  team-scoped). Passing another team\'s id fails fast with the shortest fix:
  `lsh profile use <name>` when a profile for it exists, `lsh login` otherwise,
  or a typo warning when the id is not one of your teams.
- A successful `teams update` refreshes the active profile\'s stored team
  name/slug, keeping `profile list` / `auth status` in sync.
- `--currency` is not available on `teams update`: the API only allows writing
  currency on create. The published spec still advertises it with a default, which
  makes the generated SDK inject `currency` into every PATCH — the CLI strips it
  from the wire until the spec is fixed (see workaround comment in `cli/teams.go`).
- `mfa_enabled` is always present in members JSON output (no `omitempty`).
- TTY detection now uses `isatty` instead of char-device sniffing, so piped
  commands get actionable errors instead of bubbletea TTY crashes.

## Acceptance criteria

- [x] `lsh teams members add --email new@example.com --role administrator` invites a member
- [x] `lsh teams members remove <id>` removes a member
- [x] `lsh regions list` lists every available region
- [x] `lsh ips list` lists IPs allocated to the project

## SDK / toolchain

- `latitudesh-go-sdk` `v1.9.0` → `v1.15.1` (exposes teams members, regions, IPs and
  OS endpoints; `v1.15.1` consumes the corrected `ip_address` JSON:API envelope, so
  `ips get` returns data).
- `go.mod` now requires `go 1.25.x`; `.github/workflows/release.yml` switched from a
  hardcoded `go-version: \'1.22.0\'` to `go-version-file: go.mod`.
- Adapted the existing `volume_*` operations to the renamed SDK client
  (`client.Storage` → `client.BlockStorage`) — mechanical rename, no logic changes.

## Test plan

Unit tests (no credentials needed):

```bash
go test ./...
```

Manual validation — build, authenticate once with `lsh login`, then run the
commands against the live API:

```bash
go build -o ./lsh-dev .
./lsh-dev login   # opens the browser flow and stores the profile/token

# Metadata catalogs (read-only, safe)
./lsh-dev regions list
./lsh-dev operating-systems list
./lsh-dev ips list --project=<id>
./lsh-dev ips list --all-projects --family=IPv4   # enter on a row opens details
./lsh-dev ips get <ip-id>

# Teams
./lsh-dev teams list
./lsh-dev teams members list

# Interactive forms (run in a TTY, omit the flags)
./lsh-dev teams create
./lsh-dev teams update            # uses the profile\'s team; prints which one
./lsh-dev teams members add
./lsh-dev teams members remove    # member picker + confirmation

# Flags still work for scripting (mutating — use a disposable address)
./lsh-dev teams members add --email new@example.com --role administrator
./lsh-dev teams members remove <user-id>

# Fail-fast paths
./lsh-dev teams members add --email x@y.com --role superuser   # invalid role error
echo | ./lsh-dev teams create                                  # non-TTY → --name required
./lsh-dev teams members add --email x@y.com --role billing --dry-run
```

## Notes

- Independent of #85 (PD-6074). The only shared file is `cli/cli.go`, where both PRs
  only append command registrations in distinct regions — additive, no logical overlap.
- The `ip_address` envelope fix landed in the API spec and SDK `v1.15.1` during this
  PR\'s development; a remaining spec drift (PATCH `/team` advertising `currency` /
  `referred_code`, missing `description`) is tracked separately.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds `teams`, `regions`, `ips`, and `operating-systems` CLI commands backed by the bumped Go SDK v1.15.1, with interactive TTY fallbacks for required input and an enter-to-details view on IP listings.

- **New commands**: `lsh teams {list,create,update}`, `lsh teams members {list,add,remove}`, `lsh regions list`, `lsh ips {list,get}`, `lsh operating-systems list` — all wired into the root command, paginated to exhaustion via `Next()`, guarded by dry-run, and covered by unit tests.
- **`stripTeamPatchCurrency` transport**: a custom `http.RoundTripper` strips the spec-injected `currency` field from team PATCH bodies to work around an API spec bug; scoped to the single team-update client so other commands are unaffected.
- **TTY detection fix**: `IsTTY()` now uses `term.IsTerminal` instead of `ModeCharDevice`, preventing bubbletea crashes when stdin is piped to `/dev/null`.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one targeted fix: `parseIPFamily` rejects `IPV4` and `IPV6` while the PR documents case-insensitive enum handling for all IP filters.

The `--family` filter silently produces a user-facing error for fully-uppercased input (`IPV4`, `IPV6`) because `parseIPFamily` uses explicit case matching rather than `strings.ToLower`, inconsistent with `parseIPType` and the documented behavior. Every other new command and the `stripTeamPatchCurrency` workaround look correct and well-tested.

cli/ips.go — `parseIPFamily` case normalization
</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CLI command invoked] --> B{DryRun?}
    B -- yes --> Z[Log dry-run, return]

    B -- no --> C{Interactive form needed?}
    C -- "flags provided" --> D[Build request struct]
    C -- "flags missing + TTY" --> E[Run TUI prompts]
    C -- "flags missing + no TTY" --> F[requiredFlagError, return]

    E --> D
    D --> G[lsh.NewClient + API call]

    G -- error --> H[PrintError, return]
    G -- empty --> I[renderer.Render nil]
    G -- data --> J{Paginated?}

    J -- "Next() available" --> K[Append page, call Next]
    K --> J
    J -- "Next() == nil" --> L[stopSpinner]
    L --> M{Output type?}

    M -- "IP data\nisIPData" --> N[tui.RunResourceTable\nenter-details loop]
    M -- "Server data\nisServerData" --> O[RunServersTable]
    M -- other --> P[Standard table/JSON render]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
cli/ips.go:198-206
**`parseIPFamily` is not case-insensitive for fully-uppercase input**

The PR description states that `--family` is a "case-insensitive enum," and `parseIPType` backs that up with `strings.ToLower`. But `parseIPFamily` only handles `"IPv4"`, `"ipv4"`, and `"v4"` — so `lsh ips list --family=IPV4` returns `invalid value for --family: 'IPV4' (allowed: IPv4, IPv6)` rather than filtering successfully. The test suite confirms the gap: it covers `Public` / `PRIVATE` for type, but never `IPV4` / `IPV6` for family.

### Issue 2 of 2
internal/renderer/bubbletea.go:54-64
**`isIPData` heuristic could misfire on future resources**

The function identifies IP data by checking for `address` and `family` keys in the first row. Any resource that happens to expose both fields (e.g., a network-interface or BGP session type added later) would be silently routed into the IP interactive table view. Naming the column `ip_address` / `ip_family`, or using a dedicated type tag passed through from the command layer, would make this discrimination unambiguous.

```suggestion
// isIPData checks if the data is IP address data by looking for the
// ip-specific combination of "address" + "family" table columns.
// NOTE: if a future resource type also exposes both columns, consider
// switching to an explicit marker (e.g. a dedicated ResponseDataKind
// interface) rather than this heuristic.
func isIPData(data []ResponseData) bool {
	if len(data) == 0 {
		return false
	}

	firstRow := data[0].TableRow()
	_, hasAddress := firstRow["address"]
	_, hasFamily := firstRow["family"]
	return hasAddress && hasFamily
}
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["feat(cli): interactive forms, details vi..."](https://github.com/latitudesh/cli/commit/46c3c4d7537fade39f7f82519440e4af5f49cf79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36596437)</sub>

<!-- /greptile_comment -->