### PR TITLE
fix(ci): trigger Homebrew update after release workflow to avoid asset race

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,8 +1,9 @@
 name: Update Homebrew Tap
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["release"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       version:
@@ -16,6 +17,13 @@ permissions:
 jobs:
   update-homebrew:
     runs-on: ubuntu-latest
+    # For workflow_run, only proceed when the release build succeeded and it ran for a tag (v*).
+    # This guarantees GoReleaser has already uploaded the assets, avoiding the race where a
+    # release published from the UI fires before the binaries/checksums exist.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
     steps:
       -
         name: Checkout
@@ -24,11 +32,12 @@ jobs:
         name: Get release info
         id: release_info
         run: |
-          # Use input version if running manually, otherwise use release event
+          # Use input version if running manually; otherwise derive it from the release
+          # workflow run. For tag-triggered runs, head_branch is the tag name (e.g. v1.6.1).
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION=${{ github.event.inputs.version }}
           else
-            VERSION=${{ github.event.release.tag_name }}
+            VERSION=${{ github.event.workflow_run.head_branch }}
           fi
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -47,8 +56,9 @@ jobs:
         run: |
           VERSION=${{ steps.release_info.outputs.version }}
 
-          # Download checksums file from release
-          wget -q "https://github.com/latitudesh/cli/releases/download/${VERSION}/checksums.txt"
+          # Download checksums file from release (retry to absorb asset propagation lag)
+          wget -q --tries=10 --waitretry=15 --retry-on-http-error=404,503 \
+            "https://github.com/latitudesh/cli/releases/download/${VERSION}/checksums.txt"
 
           # Extract SHA256 for each platform
           LINUX_AMD64_SHA=$(grep "lsh_Linux_x86_64.tar.gz" checksums.txt | cut -d' ' -f1)

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -35,9 +35,9 @@ jobs:
           # Use input version if running manually; otherwise derive it from the release
           # workflow run. For tag-triggered runs, head_branch is the tag name (e.g. v1.6.1).
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION=${{ github.event.inputs.version }}
+            VERSION="${{ github.event.inputs.version }}"
           else
-            VERSION=${{ github.event.workflow_run.head_branch }}
+            VERSION="${{ github.event.workflow_run.head_branch }}"
           fi
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Summary

The `Update Homebrew Tap` workflow triggered on `release: published`, which fires the moment a release is published from the GitHub UI — before GoReleaser (triggered by the same tag) uploads the binaries and `checksums.txt`. The download step then 404s (`wget` exit 8), as happened for v1.6.1.

This switches the trigger to `workflow_run` after the `release` workflow completes successfully, with a guard (success + `v*` tag ref) so the assets are guaranteed to exist. Adds a retry on the checksums download as a safety net. The manual `workflow_dispatch` path is preserved.

### Testing

- Workflow YAML validated locally.
- After merge, the next tagged release updates the tap automatically; `workflow_dispatch` with a version remains available (and can be used to backfill v1.6.1).

Relates to PD-6250.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a release asset race condition by replacing the `release: published` trigger with a `workflow_run` trigger that fires only after the `release` workflow completes successfully, ensuring GoReleaser has fully uploaded binaries and `checksums.txt` before the Homebrew tap update runs.

- **Trigger change**: `workflow_run` with `conclusion == 'success'` and `startsWith(head_branch, 'v')` guard replaces the immediate `release: published` event; `workflow_dispatch` is preserved for manual/backfill runs.
- **Retry safety net**: `wget` gains `--tries=10 --waitretry=15 --retry-on-http-error=404,503` to absorb any residual asset propagation lag after the workflow succeeds.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The core race-condition fix is correct and the retry logic is a sensible belt-and-suspenders addition, but there is an open concern in the review thread about the release workflow's two parallel jobs that has not yet been addressed.

The trigger switch and guard logic are sound — head_branch is the tag name for tag-triggered runs, workflow_run correctly waits for GoReleaser to finish, and short-circuit evaluation in the if makes the dispatch path safe. The one open question flagged in the existing thread (the generate-docs job's failure conclusion affecting the overall workflow result) remains unresolved in this PR, meaning an unrelated docs-sync failure would silently block automatic tap updates on a valid release.

.github/workflows/update-homebrew.yml and .github/workflows/release.yml together — the interaction between the two parallel jobs in the release workflow and how their combined conclusion gates this trigger warrants a second look before merging.
</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub (tag push)
    participant RW as release workflow
    participant GR as GoReleaser
    participant UH as update-homebrew workflow
    participant HT as homebrew-tools repo

    Dev->>GH: "git push tag v*"
    GH->>RW: "trigger (push: tags v*)"
    RW->>GR: goreleaser release
    GR->>GH: upload binaries + checksums.txt

    Note over GH,RW: [Before this PR] release:published fired here before GoReleaser finished — assets missing → 404

    GH->>UH: "workflow_run (completed, conclusion=success)"
    UH->>UH: "guard: conclusion==success && head_branch startsWith 'v'"
    UH->>GH: "wget --tries=10 checksums.txt (with retry)"
    UH->>HT: create PR updating lsh.rb formula
```

<sub>Reviews (2): Last reviewed commit: ["fix(ci): quote VERSION assignments to pr..."](https://github.com/latitudesh/cli/commit/0d261e62a548a7c66181dba2b9d00b68c301d0a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36833618)</sub>

<!-- /greptile_comment -->