### PR TITLE
feat(cli): waiters, streaming and polling — --wait and events --follow (PD-6073)

### DIFF
--- a/cli/create_server_operation.go
+++ b/cli/create_server_operation.go
@@ -9,6 +9,7 @@ import (
 	"github.com/latitudesh/lsh/internal/api/resource"
 	"github.com/latitudesh/lsh/internal/cmdflag"
 	"github.com/latitudesh/lsh/internal/utils"
+	"github.com/latitudesh/lsh/internal/wait"
 
 	"github.com/spf13/cobra"
 )
@@ -53,6 +54,7 @@ func (o *CreateServerOperation) Register() (*cobra.Command, error) {
 	}
 
 	o.registerFlags(cmd)
+	wait.AddFlags(cmd)
 
 	return cmd, nil
 }
@@ -160,11 +162,21 @@ func (o *CreateServerOperation) run(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if !lsh.Debug {
+	waitOpts := wait.OptionsFrom(cmd)
+
+	// When waiting, the create payload is an optimistic snapshot (it can report
+	// "on" while the server is still deploying); skip it and let the wait render
+	// the real final state instead.
+	if !lsh.Debug && !waitOpts.Enabled {
 		utils.Render(response.GetData())
 	}
 
-	return nil
+	var serverID string
+	if p := response.GetPayload(); p != nil && p.Data != nil {
+		serverID = p.Data.ID
+	}
+	want, fail := serverProvisionTargets()
+	return waitForServerState(cmd, serverID, want, fail)
 }
 
 func fetchUserProjects() []string {

--- a/cli/create_server_reinstall_operation.go
+++ b/cli/create_server_reinstall_operation.go
@@ -8,6 +8,7 @@ import (
 	"github.com/latitudesh/lsh/internal/api/resource"
 	"github.com/latitudesh/lsh/internal/cmdflag"
 	"github.com/latitudesh/lsh/internal/utils"
+	"github.com/latitudesh/lsh/internal/wait"
 
 	"github.com/go-openapi/swag"
 	"github.com/spf13/cobra"
@@ -41,6 +42,7 @@ func (o *CreateServerReinstallOperation) Register() (*cobra.Command, error) {
 	}
 
 	o.registerFlags(cmd)
+	wait.AddFlags(cmd)
 
 	return cmd, nil
 }
@@ -136,8 +138,12 @@ func (o *CreateServerReinstallOperation) run(cmd *cobra.Command, args []string) 
 		return nil
 	}
 
-	if !lsh.Debug {
+	waitEnabled := wait.OptionsFrom(cmd).Enabled
+	if !lsh.Debug && !waitEnabled {
 		response.Render()
 	}
-	return nil
+
+	serverID, _ := cmd.Flags().GetString("id")
+	want, fail := serverProvisionTargets()
+	return waitForServerState(cmd, serverID, want, fail)
 }

--- a/cli/server_wait.go
+++ b/cli/server_wait.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
+	"github.com/latitudesh/lsh/client/servers"
+	"github.com/latitudesh/lsh/cmd/lsh"
+	"github.com/latitudesh/lsh/internal/utils"
+	"github.com/latitudesh/lsh/internal/wait"
+	"github.com/spf13/cobra"
+)
+
+// waitForServerState blocks until the server reaches one of want, hits one of
+// fail, times out, or the user cancels — but only when --wait was passed.
+//
+// The create/reinstall calls still go through the legacy client; the wait loop
+// polls via the SDK (Servers.Get). Progress and outcome are written to stderr
+// so they never corrupt structured (-o json) output on stdout.
+func waitForServerState(cmd *cobra.Command, serverID string, want, fail []components.ServerDataStatus) error {
+	o := wait.OptionsFrom(cmd)
+	if !o.Enabled {
+		if cmd.Flags().Changed("timeout") {
+			fmt.Fprintln(os.Stderr, "warning: --timeout has no effect without --wait")
+		}
+		return nil
+	}
+	if serverID == "" {
+		fmt.Fprintln(os.Stderr, "warning: --wait ignored: could not determine the server ID")
+		return nil
+	}
+
+	client := lsh.NewClient()
+	ctx, cancel := wait.SignalContext(context.Background())
+	defer cancel()
+
+	fmt.Fprintf(os.Stderr, "Waiting for server %s to finish provisioning… (Ctrl+C to stop)\n", serverID)
+
+	status, err := wait.ForServerState(ctx, client, serverID, want, fail, true, o, nil, operations.WithRetries(lsh.RetryConfig()))
+	switch {
+	case errors.Is(err, wait.ErrCanceled):
+		return fmt.Errorf("wait canceled (last status: %s)", status)
+	case errors.Is(err, wait.ErrTimeout):
+		return fmt.Errorf("timed out waiting for server %s (last status: %s)", serverID, status)
+	case errors.Is(err, wait.ErrFailedState):
+		return fmt.Errorf("server %s entered a failed state: %s", serverID, status)
+	case err != nil:
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "Server %s is now %q\n", serverID, status)
+
+	// The create/reinstall payload is an optimistic snapshot (it can report
+	// "on" mid-deploy); render the real, final state by re-fetching the server.
+	if !lsh.Debug {
+		renderServerState(cmd, serverID)
+	}
+	return nil
+}
+
+// renderServerState re-fetches the server and renders its current state without
+// the interactive table. Best-effort: a failed re-fetch is silent because the
+// wait itself already succeeded.
+func renderServerState(cmd *cobra.Command, serverID string) {
+	appCli, err := makeClient(cmd, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not render final server state: %v\n", err)
+		return
+	}
+	params := servers.NewGetServerParams()
+	params.SetServerID(serverID)
+	resp, err := appCli.Servers.GetServer(params, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not fetch final server state: %v\n", err)
+		return
+	}
+	utils.RenderStatic(resp.GetData())
+}
+
+// serverProvisionTargets are the terminal states for a create/reinstall wait.
+// Provisioning is "done" once the server settles into a stable power state —
+// it may finish either powered on or off — and "failed" on a failed deployment.
+// The in-progress states (deploying, disk_erasing) keep the wait polling.
+func serverProvisionTargets() (want, fail []components.ServerDataStatus) {
+	return []components.ServerDataStatus{
+			components.ServerDataStatusOn,
+			components.ServerDataStatusOff,
+		},
+		[]components.ServerDataStatus{components.ServerDataStatusFailedDeployment}
+}

--- a/cmd/events/follow_test.go
+++ b/cmd/events/follow_test.go
@@ -1,0 +1,215 @@
+package events
+
+import (
+	"testing"
+	"time"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
+)
+
+func TestFollowCursor(t *testing.T) {
+	now := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+
+	t.Run("no --since seeds from now", func(t *testing.T) {
+		got := followCursor(&operations.GetEventsRequest{}, now)
+		if !got.Equal(now) {
+			t.Errorf("got %v, want %v", got, now)
+		}
+	})
+
+	t.Run("--since seeds from the gte instant", func(t *testing.T) {
+		gte := "2026-06-17T08:30:00" // FormatISO8601 output
+		got := followCursor(&operations.GetEventsRequest{FilterCreatedAtGte: &gte}, now)
+		want := time.Date(2026, 6, 17, 8, 30, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+		if got.Location() != time.UTC {
+			t.Errorf("cursor not in UTC: %v", got.Location())
+		}
+	})
+
+	t.Run("unparseable gte falls back to now", func(t *testing.T) {
+		bad := "nonsense"
+		got := followCursor(&operations.GetEventsRequest{FilterCreatedAtGte: &bad}, now)
+		if !got.Equal(now) {
+			t.Errorf("got %v, want %v", got, now)
+		}
+	})
+}
+
+func TestEventTime(t *testing.T) {
+	str := func(s string) *string { return &s }
+
+	cases := []struct {
+		name    string
+		in      *components.EventData
+		wantOK  bool
+		wantUTC string // expected RFC3339-ish, second precision, UTC
+	}{
+		{
+			name:   "nil attributes",
+			in:     &components.EventData{},
+			wantOK: false,
+		},
+		{
+			name:   "nil created_at",
+			in:     &components.EventData{Attributes: &components.EventDataAttributes{}},
+			wantOK: false,
+		},
+		{
+			name:    "rfc3339 with zone",
+			in:      &components.EventData{Attributes: &components.EventDataAttributes{CreatedAt: str("2026-06-18T15:04:05-03:00")}},
+			wantOK:  true,
+			wantUTC: "2026-06-18T18:04:05Z",
+		},
+		{
+			name:    "no zone (API filter format)",
+			in:      &components.EventData{Attributes: &components.EventDataAttributes{CreatedAt: str("2026-06-18T18:04:05")}},
+			wantOK:  true,
+			wantUTC: "2026-06-18T18:04:05Z",
+		},
+		{
+			name:   "unparseable",
+			in:     &components.EventData{Attributes: &components.EventDataAttributes{CreatedAt: str("nonsense")}},
+			wantOK: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := eventTime(c.in)
+			if ok != c.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, c.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got.Location() != time.UTC {
+				t.Errorf("time not in UTC: %v", got.Location())
+			}
+			if g := got.Format(time.RFC3339); g != c.wantUTC {
+				t.Errorf("got %s, want %s", g, c.wantUTC)
+			}
+		})
+	}
+}
+
+func TestFollowCursorRFC3339(t *testing.T) {
+	now := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	// A timezone-bearing gte (forward-compat with a future FormatISO8601) must
+	// still parse instead of silently falling back to now.
+	gte := "2026-06-17T08:30:00-03:00"
+	got := followCursor(&operations.GetEventsRequest{FilterCreatedAtGte: &gte}, now)
+	want := time.Date(2026, 6, 17, 11, 30, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestDedupKey(t *testing.T) {
+	str := func(s string) *string { return &s }
+
+	t.Run("prefers the event ID", func(t *testing.T) {
+		ev := &components.EventData{ID: str("evt_123")}
+		if got := dedupKey(ev); got != "evt_123" {
+			t.Errorf("got %q, want evt_123", got)
+		}
+	})
+
+	t.Run("synthetic key when ID missing", func(t *testing.T) {
+		ev := &components.EventData{
+			Attributes: &components.EventDataAttributes{
+				Action:    str("servers.update"),
+				CreatedAt: str("2026-06-18T12:00:00"),
+				Target:    &components.Target{ID: str("sv_x")},
+			},
+		}
+		k1 := dedupKey(ev)
+		k2 := dedupKey(ev)
+		if k1 != k2 {
+			t.Errorf("synthetic key not stable: %q vs %q", k1, k2)
+		}
+		if k1 == "" {
+			t.Error("synthetic key should not be empty")
+		}
+	})
+
+	t.Run("distinct events get distinct keys", func(t *testing.T) {
+		a := &components.EventData{Attributes: &components.EventDataAttributes{
+			Action: str("servers.update"), CreatedAt: str("2026-06-18T12:00:00"),
+		}}
+		b := &components.EventData{Attributes: &components.EventDataAttributes{
+			Action: str("servers.create"), CreatedAt: str("2026-06-18T12:00:00"),
+		}}
+		if dedupKey(a) == dedupKey(b) {
+			t.Error("expected distinct keys for distinct events")
+		}
+	})
+}
+
+func TestEventDeduper(t *testing.T) {
+	str := func(s string) *string { return &s }
+	at := func(id, ts string) components.EventData {
+		return components.EventData{ID: str(id), Attributes: &components.EventDataAttributes{
+			Action: str("servers.update"), CreatedAt: str(ts),
+		}}
+	}
+	ids := func(evs []*components.EventData) []string {
+		out := make([]string, 0, len(evs))
+		for _, e := range evs {
+			if e.ID != nil {
+				out = append(out, *e.ID)
+			} else {
+				out = append(out, "<nil>")
+			}
+		}
+		return out
+	}
+
+	t.Run("emits oldest-first and de-dupes the boundary second across polls", func(t *testing.T) {
+		d := newEventDeduper(time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC))
+		// API returns newest-first.
+		page1 := []components.EventData{at("evt_b", "2026-06-18T12:00:05"), at("evt_a", "2026-06-18T12:00:01")}
+		got := ids(d.next(page1))
+		if len(got) != 2 || got[0] != "evt_a" || got[1] != "evt_b" {
+			t.Fatalf("poll1 = %v, want [evt_a evt_b]", got)
+		}
+		// Poll 2: inclusive gte re-returns evt_b (boundary second) plus a new one.
+		page2 := []components.EventData{at("evt_c", "2026-06-18T12:00:05"), at("evt_b", "2026-06-18T12:00:05")}
+		got = ids(d.next(page2))
+		if len(got) != 1 || got[0] != "evt_c" {
+			t.Fatalf("poll2 = %v, want [evt_c] (evt_b already shown)", got)
+		}
+	})
+
+	t.Run("empty page does not drop boundary dedup state (P1 regression)", func(t *testing.T) {
+		d := newEventDeduper(time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC))
+		if got := ids(d.next([]components.EventData{at("evt_a", "2026-06-18T12:00:05")})); len(got) != 1 || got[0] != "evt_a" {
+			t.Fatalf("poll1 = %v, want [evt_a]", got)
+		}
+		// A transient empty page must not wipe the boundary-second set.
+		if got := ids(d.next(nil)); len(got) != 0 {
+			t.Fatalf("poll2 (empty) = %v, want []", got)
+		}
+		// evt_a comes back (cursor unchanged, gte inclusive) and must not repeat.
+		if got := ids(d.next([]components.EventData{at("evt_a", "2026-06-18T12:00:05")})); len(got) != 0 {
+			t.Fatalf("poll3 = %v, want [] (evt_a already shown)", got)
+		}
+	})
+
+	t.Run("undated event is emitted exactly once (P1 regression)", func(t *testing.T) {
+		d := newEventDeduper(time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC))
+		undated := components.EventData{ID: str("evt_x")} // nil Attributes → unparseable time
+		page := []components.EventData{undated}
+
+		if got := ids(d.next(page)); len(got) != 1 || got[0] != "evt_x" {
+			t.Fatalf("poll1 = %v, want [evt_x]", got)
+		}
+		// Same event returned again on the next poll must NOT be reprinted.
+		if got := ids(d.next([]components.EventData{undated})); len(got) != 0 {
+			t.Fatalf("poll2 = %v, want [] (undated event must not repeat)", got)
+		}
+	})
+}

--- a/cmd/events/list.go
+++ b/cmd/events/list.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -10,7 +11,9 @@ import (
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
 	"github.com/latitudesh/lsh/cli"
 	"github.com/latitudesh/lsh/cmd/lsh"
+	"github.com/latitudesh/lsh/internal/renderer"
 	"github.com/latitudesh/lsh/internal/utils"
+	"github.com/latitudesh/lsh/internal/wait"
 	cobra "github.com/spf13/cobra"
 )
 
@@ -28,11 +31,13 @@ func NewListCmd() *cobra.Command {
 		Short: "List events",
 		Example: `  lsh events list --since 24h --target-type Server
   lsh events list --author user@example.com
-  lsh events list --project my-project --action update --since 2026-06-01`,
+  lsh events list --project my-project --action update --since 2026-06-01
+  lsh events list --follow --target-id sv_xxxx`,
 		Use:         "list",
 		Annotations: map[string]string{cli.ProjectOptionalAnnotation: "true"},
 	}
 
+	cmd.Flags().BoolP("follow", "f", false, "stream new events as they occur (polls forward; Ctrl+C to stop)")
 	cmd.Flags().String("author", "", "Filter by author ID or email")
 	cmd.Flags().String("project", "", "Filter by project ID or slug")
 	cmd.Flags().StringSlice("target-type", nil, "Filter by target type (repeatable), e.g. servers, projects, virtual_networks")
@@ -56,6 +61,10 @@ func (o *ListEventsOperation) run(cmd *cobra.Command, args []string) error {
 	if lsh.DryRun {
 		lsh.LogDebugf("dry-run flag specified. Skip sending request.")
 		return nil
+	}
+
+	if follow, _ := cmd.Flags().GetBool("follow"); follow {
+		return followEvents(request, time.Now())
 	}
 
 	client := lsh.NewClient()
@@ -147,4 +156,264 @@ func buildEventsRequest(cmd *cobra.Command, now time.Time) (*operations.GetEvent
 	}
 
 	return &request, nil
+}
+
+// followEvents streams new events forever, advancing filter[created_at][gte]
+// past the newest event seen and printing each new event in chronological
+// order. It stops cleanly on Ctrl+C (SIGINT/SIGTERM).
+//
+// The events endpoint orders newest-first and has only second-granular
+// timestamps, so the cursor is inclusive (gte) and we de-duplicate by event ID
+// within the boundary second to avoid reprinting events we already showed.
+func followEvents(request *operations.GetEventsRequest, now time.Time) error {
+	client := lsh.NewClient()
+	ctx, cancel := wait.SignalContext(context.Background())
+	defer cancel()
+
+	// Streaming has no upper bound; an --until would only stop the tail early.
+	// Make the drop explicit instead of silently ignoring it.
+	if request.FilterCreatedAtLte != nil {
+		fmt.Fprintln(os.Stderr, "warning: --until is ignored with --follow")
+		request.FilterCreatedAtLte = nil
+	}
+	pageSize := int64(eventsPageSize)
+	request.PageSize = &pageSize
+	page := int64(1)
+	request.PageNumber = &page
+
+	// Without an explicit --since we only want events from now on, so the user
+	// isn't flooded with history. With --since, the first poll seeds from there.
+	// The probe re-derives filter[created_at][gte] from the cursor every poll.
+	deduper := newEventDeduper(followCursor(request, now))
+
+	// --follow streams plain text; structured formats don't fit an open-ended
+	// tail, so make the bypass explicit instead of silently ignoring -o.
+	if f := renderer.ResolveFormat(); f.IsStructured() {
+		fmt.Fprintf(os.Stderr, "warning: --follow streams plain text; -o %s is ignored\n", f)
+	}
+
+	fmt.Fprintln(os.Stderr, "Following events… press Ctrl+C to stop")
+
+	// Cap the poll at 5s to honor the freshness target, with a 1s floor (the
+	// shared pollFloor) keeping us within the 1 req/s budget.
+	backoff := wait.Backoff{Initial: 2 * time.Second, Max: 5 * time.Second, Factor: 1.5}
+
+	// We only fetch the first page each poll. A full page means more matching
+	// events may exist beyond it; under high event rates the older ones fall
+	// below the advancing cursor and are skipped. Warn once so the gap isn't
+	// silent.
+	truncationWarned := false
+
+	err := wait.Poll(ctx, backoff, func(ctx context.Context) (bool, error) {
+		gte := utils.FormatISO8601(deduper.cursor)
+		request.FilterCreatedAtGte = &gte
+
+		response, err := client.Events.List(ctx, *request, operations.WithRetries(lsh.RetryConfig()))
+		if err != nil {
+			// A transient failure shouldn't kill a long-running stream.
+			fmt.Fprintf(os.Stderr, "warning: events poll failed: %v\n", err)
+			return false, nil
+		}
+
+		var data []components.EventData
+		if response.Events != nil {
+			data = response.Events.Data
+		}
+
+		if len(data) >= eventsPageSize && !truncationWarned {
+			fmt.Fprintf(os.Stderr, "warning: more than %d events in a single interval; some older events may be skipped — narrow the filter to follow them all\n", eventsPageSize)
+			truncationWarned = true
+		}
+
+		for _, ev := range deduper.next(data) {
+			printEventLine(ev)
+		}
+		return false, nil // follow forever
+	})
+
+	if errors.Is(err, wait.ErrCanceled) {
+		return nil // clean Ctrl+C
+	}
+	return err
+}
+
+// eventDeduper turns successive newest-first event pages into a de-duplicated,
+// oldest-first stream. It advances an inclusive, second-granular cursor and —
+// for events whose timestamp can't be parsed, and so can't ride the cursor —
+// tracks them in a persistent set so each is emitted exactly once.
+type eventDeduper struct {
+	cursor      time.Time
+	printed     map[string]struct{} // keys at the cursor second (rebuilt each page)
+	seenUndated map[string]struct{} // keys with no parseable time (persistent)
+}
+
+func newEventDeduper(cursor time.Time) *eventDeduper {
+	return &eventDeduper{
+		cursor:      cursor,
+		printed:     map[string]struct{}{},
+		seenUndated: map[string]struct{}{},
+	}
+}
+
+// next returns the events from page (API order, newest-first) not yet emitted,
+// in chronological (oldest-first) order, advancing the cursor past the newest.
+func (d *eventDeduper) next(page []components.EventData) []*components.EventData {
+	newMax := d.cursor
+	nextPrinted := map[string]struct{}{}
+	var out []*components.EventData
+
+	for i := len(page) - 1; i >= 0; i-- {
+		ev := &page[i]
+		key := dedupKey(ev)
+		ts, ok := eventTime(ev)
+
+		// Undated events can't ride the cursor; emit each exactly once.
+		if !ok {
+			if _, seen := d.seenUndated[key]; seen {
+				continue
+			}
+			out = append(out, ev)
+			d.seenUndated[key] = struct{}{}
+			continue
+		}
+
+		if _, seen := d.printed[key]; seen {
+			// Already shown; keep tracking it while it sits on the boundary second.
+			if ts.Equal(newMax) {
+				nextPrinted[key] = struct{}{}
+			}
+			continue
+		}
+
+		out = append(out, ev)
+		if ts.After(newMax) {
+			newMax = ts
+			// Boundary second moved forward; drop stale keys.
+			nextPrinted = map[string]struct{}{}
+		}
+		if ts.Equal(newMax) {
+			nextPrinted[key] = struct{}{}
+		}
+	}
+
+	// If the cursor didn't advance (empty page, a page of only undated events,
+	// or a transient API inconsistency), keep the boundary-second keys we already
+	// knew so those events aren't re-emitted when they reappear on a later poll.
+	if newMax.Equal(d.cursor) {
+		for k := range d.printed {
+			nextPrinted[k] = struct{}{}
+		}
+	}
+	d.cursor = newMax
+	d.printed = nextPrinted
+
+	// Bound the persistent undated set. Malformed timestamps should be rare, but
+	// over a long-running stream this guards against unbounded growth; clearing
+	// may re-emit a handful of undated events once — an acceptable trade.
+	const maxUndated = 4096
+	if len(d.seenUndated) > maxUndated {
+		d.seenUndated = map[string]struct{}{}
+	}
+
+	return out
+}
+
+// followCursor returns the starting cursor for the --follow stream: the --since
+// instant when one was supplied (request.FilterCreatedAtGte), otherwise now.
+// The result is second-truncated UTC to match the API's timestamp granularity.
+func followCursor(request *operations.GetEventsRequest, now time.Time) time.Time {
+	if request.FilterCreatedAtGte != nil {
+		if t, ok := parseEventTimestamp(*request.FilterCreatedAtGte); ok {
+			return t
+		}
+	}
+	return now.UTC().Truncate(time.Second)
+}
+
+// eventTime parses an event's created_at into a second-truncated UTC time.
+func eventTime(ev *components.EventData) (time.Time, bool) {
+	if ev.Attributes == nil || ev.Attributes.CreatedAt == nil {
+		return time.Time{}, false
+	}
+	return parseEventTimestamp(*ev.Attributes.CreatedAt)
+}
+
+// parseEventTimestamp parses an events-API timestamp into a second-truncated
+// UTC time, tolerating the formats the endpoint may emit (with or without a
+// timezone). Shared by followCursor and eventTime so the two never diverge.
+func parseEventTimestamp(s string) (time.Time, bool) {
+	layouts := []string{
+		time.RFC3339, // == "2006-01-02T15:04:05Z07:00"
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05 -0700 MST",
+		"2006-01-02 15:04:05 -0700",
+		"2006-01-02 15:04:05",
+	}
+	for _, l := range layouts {
+		if t, err := time.Parse(l, s); err == nil {
+			return t.UTC().Truncate(time.Second), true
+		}
+	}
+	return time.Time{}, false
+}
+
+// dedupKey returns a stable key for de-duplicating events across polls. It
+// prefers the event ID; when the API omits it, it falls back to a synthetic
+// key so ID-less events aren't reprinted on every poll within a boundary second.
+func dedupKey(ev *components.EventData) string {
+	if ev.ID != nil && *ev.ID != "" {
+		return *ev.ID
+	}
+	get := func(p *string) string {
+		if p != nil {
+			return *p
+		}
+		return ""
+	}
+	var action, createdAt, targetID string
+	if a := ev.Attributes; a != nil {
+		action = get(a.Action)
+		createdAt = get(a.CreatedAt)
+		if a.Target != nil {
+			targetID = get(a.Target.ID)
+		}
+	}
+	return fmt.Sprintf("synthetic:%s|%s|%s", action, createdAt, targetID)
+}
+
+// printEventLine writes a compact, plain one-line representation of an event to
+// stdout — the streaming counterpart to the table renderer.
+func printEventLine(ev *components.EventData) {
+	get := func(p *string) string {
+		if p != nil {
+			return *p
+		}
+		return ""
+	}
+
+	var action, createdAt, author, target string
+	if a := ev.Attributes; a != nil {
+		action = get(a.Action)
+		createdAt = get(a.CreatedAt)
+		if a.Author != nil {
+			author = get(a.Author.Email)
+		}
+		if a.Target != nil {
+			target = get(a.Target.Name)
+			if id := get(a.Target.ID); id != "" {
+				if target != "" {
+					target = fmt.Sprintf("%s (%s)", target, id)
+				} else {
+					target = id
+				}
+			}
+		}
+	}
+
+	// Normalise to a fixed-width RFC3339 string so the action/target columns
+	// don't shift when the API mixes timezone-bearing and bare timestamps.
+	if t, ok := parseEventTimestamp(createdAt); ok {
+		createdAt = t.Format(time.RFC3339)
+	}
+	fmt.Printf("%-20s  %-24s  %-30s  %s\n", createdAt, action, target, author)
 }

--- a/internal/renderer/main.go
+++ b/internal/renderer/main.go
@@ -41,8 +41,28 @@ func GetRenderer() Renderer {
 	return BubbleTeaRenderer{}
 }
 
+// GetStaticRenderer is like GetRenderer but never returns the interactive
+// Bubble Tea view. Use it for flows where taking over the terminal is wrong —
+// e.g. a `--wait` that must print the resource and then keep streaming progress.
+func GetStaticRenderer() Renderer {
+	switch ResolveFormat() {
+	case FormatJSON:
+		return JSONRenderer{}
+	case FormatYAML:
+		return YAMLRenderer{}
+	case FormatCSV:
+		return CSVRenderer{}
+	}
+	return TableRenderer{} // plain ASCII, no full-screen takeover
+}
+
 // Render renders the data using the appropriate renderer
 func Render(data []ResponseData) {
 	renderer := GetRenderer()
 	renderer.Render(data)
+}
+
+// RenderStatic renders data without the interactive table.
+func RenderStatic(data []ResponseData) {
+	GetStaticRenderer().Render(data)
 }

--- a/internal/utils/response_utils.go
+++ b/internal/utils/response_utils.go
@@ -13,6 +13,12 @@ func Render(data []renderer.ResponseData) {
 	renderer.Render(data)
 }
 
+// RenderStatic renders without the interactive table — for flows like --wait
+// where a full-screen takeover would interrupt progress output.
+func RenderStatic(data []renderer.ResponseData) {
+	renderer.RenderStatic(data)
+}
+
 // PrintError prints a formatted error. Recognized API failures are
 // rewritten as actionable guidance for the user (e.g. 401 → "run lsh login").
 func PrintError(err error) {

--- a/internal/wait/server.go
+++ b/internal/wait/server.go
@@ -1,0 +1,148 @@
+package wait
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	sdk "github.com/latitudesh/latitudesh-go-sdk"
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
+)
+
+// ErrFailedState is returned when a server reaches a state the caller declared
+// as terminal-failure (e.g. failed_deployment) instead of its target state.
+var ErrFailedState = errors.New("server entered a failed state")
+
+// ForServerState polls GET /servers/{id} until the server's status is one of
+// want (success), one of fail (returns ErrFailedState), o.Timeout elapses
+// (ErrTimeout), or the user cancels (ErrCanceled). It returns the last status
+// observed and invokes onStatus (when non-nil) on every successful poll.
+//
+// When requireTransition is true, a terminal state is only accepted after the
+// server has first been observed in some other (transition) state. This guards
+// operations that act on a server already sitting in a target state — e.g. a
+// reinstall on a powered-on server, or a create whose POST response optimistically
+// reports "on" — from returning before the operation has actually begun.
+//
+// Transient errors from the API (the platform occasionally 5xxs mid-provision)
+// are not fatal: they are swallowed and retried until the timeout, at which
+// point the last error is attached to ErrTimeout so the failure is diagnosable.
+func ForServerState(
+	ctx context.Context,
+	client *sdk.Latitudesh,
+	serverID string,
+	want, fail []components.ServerDataStatus,
+	requireTransition bool,
+	o Options,
+	onStatus func(components.ServerDataStatus),
+	opts ...operations.Option,
+) (components.ServerDataStatus, error) {
+	if o.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, o.Timeout)
+		defer cancel()
+	}
+
+	var (
+		last           components.ServerDataStatus
+		lastErr        error
+		seenTransition bool
+	)
+
+	err := Poll(ctx, DefaultBackoff(), func(ctx context.Context) (bool, error) {
+		resp, err := client.Servers.Get(ctx, serverID, nil, opts...)
+		if err != nil {
+			// 4xx (bad ID, revoked token, …) won't fix itself by waiting — fail
+			// fast. 5xx / 429 / connection errors are transient: keep polling and
+			// surface the last one only if we ultimately time out.
+			if isTerminalAPIError(err) {
+				return false, err
+			}
+			lastErr = err
+			return false, nil
+		}
+
+		status := serverStatus(resp)
+		if status == nil {
+			return false, nil
+		}
+		last = *status
+		if onStatus != nil {
+			onStatus(*status)
+		}
+
+		done, transitioned, decideErr := decideServerState(*status, want, fail, requireTransition, seenTransition)
+		seenTransition = transitioned
+		if decideErr != nil {
+			return false, decideErr
+		}
+		return done, nil
+	})
+
+	if errors.Is(err, ErrTimeout) && lastErr != nil {
+		return last, fmt.Errorf("%w (last API error: %v)", ErrTimeout, lastErr)
+	}
+	return last, err
+}
+
+// decideServerState evaluates a single observed status against the target sets.
+// It returns whether the wait is satisfied, the updated seenTransition flag, and
+// a terminal error when the server reached a failure state.
+//
+// Failure states are reported immediately, even before a transition state was
+// observed — only the success path is gated on requireTransition, so that an
+// operation acting on a server already in a target state (e.g. a reinstall on a
+// powered-on server) does not return before it actually begins.
+func decideServerState(
+	status components.ServerDataStatus,
+	want, fail []components.ServerDataStatus,
+	requireTransition, seenTransition bool,
+) (done bool, transitioned bool, err error) {
+	inWant := containsStatus(want, status)
+	inFail := containsStatus(fail, status)
+	if !inWant && !inFail {
+		seenTransition = true
+	}
+
+	if inFail {
+		return false, seenTransition, fmt.Errorf("%w: %q", ErrFailedState, status)
+	}
+	if inWant && (!requireTransition || seenTransition) {
+		return true, seenTransition, nil
+	}
+	return false, seenTransition, nil
+}
+
+// isTerminalAPIError reports whether err is a client (4xx, except 429) API
+// error — one that will not resolve by waiting and should abort the poll.
+func isTerminalAPIError(err error) bool {
+	var apiErr *components.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.StatusCode {
+	case 408, 425, 429:
+		// Request Timeout / Too Early / Too Many Requests are transient.
+		return false
+	}
+	return apiErr.StatusCode >= 400 && apiErr.StatusCode < 500
+}
+
+// serverStatus extracts the status from a GetServer response, tolerating any
+// nil link in the data → attributes → status chain.
+func serverStatus(resp *operations.GetServerResponse) *components.ServerDataStatus {
+	if resp == nil || resp.Server == nil || resp.Server.Data == nil || resp.Server.Data.Attributes == nil {
+		return nil
+	}
+	return resp.Server.Data.Attributes.Status
+}
+
+func containsStatus(set []components.ServerDataStatus, s components.ServerDataStatus) bool {
+	for _, v := range set {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/wait/wait.go
+++ b/internal/wait/wait.go
@@ -1,0 +1,130 @@
+// Package wait provides reusable polling infrastructure shared by the
+// `--wait` flag (block until a resource reaches a target state) and the
+// `events list --follow` stream. It owns three concerns: a context-aware
+// polling loop with bounded backoff, the `--wait`/`--timeout` flag pair, and
+// a signal-derived context so Ctrl+C exits cleanly (no traceback).
+package wait
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// Sentinel errors returned by Poll and its callers. Commands map ErrTimeout to
+// a non-zero exit code; ErrCanceled is the clean Ctrl+C path.
+var (
+	ErrTimeout  = errors.New("timed out waiting for the resource to reach its target state")
+	ErrCanceled = errors.New("wait canceled")
+)
+
+// pollFloor is the minimum delay between two polls. It enforces the
+// "≤ 1 req/s under steady state" budget no matter how the backoff is tuned.
+const pollFloor = time.Second
+
+// Backoff controls the delay between polls. The delay grows geometrically from
+// Initial by Factor, capped at Max, and is never shorter than pollFloor.
+type Backoff struct {
+	Initial time.Duration
+	Max     time.Duration
+	Factor  float64
+}
+
+// DefaultBackoff is tuned for resource-state waiters: a quick first re-check
+// that eases off so a long provision doesn't hammer the API.
+func DefaultBackoff() Backoff {
+	return Backoff{Initial: 2 * time.Second, Max: 15 * time.Second, Factor: 1.5}
+}
+
+// next returns the delay that should follow a poll whose preceding delay was
+// prev. The first delay (prev <= 0) is Initial.
+func (b Backoff) next(prev time.Duration) time.Duration {
+	var d time.Duration
+	if prev <= 0 {
+		d = b.Initial
+	} else {
+		d = time.Duration(float64(prev) * b.Factor)
+	}
+	if d < pollFloor {
+		d = pollFloor
+	}
+	if b.Max > 0 && d > b.Max {
+		d = b.Max
+	}
+	return d
+}
+
+// Poll calls probe immediately, then repeatedly with a backoff delay between
+// attempts, until probe reports done, probe returns an error, or ctx is
+// cancelled/expired. A (false, nil) result means "not there yet — keep
+// waiting". Context cancellation is normalized to ErrCanceled/ErrTimeout so
+// callers get a stable, friendly error regardless of where it was observed.
+func Poll(ctx context.Context, b Backoff, probe func(context.Context) (done bool, err error)) error {
+	var delay time.Duration
+	for {
+		if delay > 0 {
+			timer := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return classify(ctx.Err())
+			case <-timer.C:
+			}
+		} else if err := ctx.Err(); err != nil {
+			// Honor an already-cancelled context before the first probe.
+			return classify(err)
+		}
+
+		done, err := probe(ctx)
+		if err != nil {
+			return err
+		}
+		if done {
+			return nil
+		}
+		delay = b.next(delay)
+	}
+}
+
+// classify maps raw context errors to this package's sentinels.
+func classify(err error) error {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return ErrTimeout
+	case errors.Is(err, context.Canceled):
+		return ErrCanceled
+	default:
+		return err
+	}
+}
+
+// Options is the parsed form of the --wait/--timeout flags.
+type Options struct {
+	Enabled bool
+	Timeout time.Duration
+}
+
+// AddFlags registers the --wait/--timeout pair on a state-changing command.
+func AddFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("wait", false, "block until the resource reaches its target state")
+	cmd.Flags().Duration("timeout", 10*time.Minute, "maximum time to wait when --wait is set (e.g. 30s, 5m)")
+}
+
+// OptionsFrom reads the --wait/--timeout flags registered by AddFlags.
+func OptionsFrom(cmd *cobra.Command) Options {
+	enabled, _ := cmd.Flags().GetBool("wait")
+	timeout, _ := cmd.Flags().GetDuration("timeout")
+	return Options{Enabled: enabled, Timeout: timeout}
+}
+
+// SignalContext derives a context that is cancelled on SIGINT (Ctrl+C) or
+// SIGTERM, so long-running waits and the --follow stream stop cleanly. The
+// returned cancel func must be called to release the signal handler.
+func SignalContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+}

--- a/internal/wait/wait_test.go
+++ b/internal/wait/wait_test.go
@@ -1,0 +1,205 @@
+package wait
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
+)
+
+func TestBackoffNext(t *testing.T) {
+	b := Backoff{Initial: 2 * time.Second, Max: 10 * time.Second, Factor: 2}
+
+	cases := []struct {
+		prev time.Duration
+		want time.Duration
+	}{
+		{0, 2 * time.Second},               // first delay is Initial
+		{2 * time.Second, 4 * time.Second}, // grows by Factor
+		{4 * time.Second, 8 * time.Second},
+		{8 * time.Second, 10 * time.Second}, // capped at Max
+	}
+	for _, c := range cases {
+		if got := b.next(c.prev); got != c.want {
+			t.Errorf("next(%v) = %v, want %v", c.prev, got, c.want)
+		}
+	}
+}
+
+func TestBackoffNextRespectsFloor(t *testing.T) {
+	// A sub-second Initial must be lifted to the 1 req/s floor.
+	b := Backoff{Initial: 100 * time.Millisecond, Max: 5 * time.Second, Factor: 1.5}
+	if got := b.next(0); got < pollFloor {
+		t.Errorf("next(0) = %v, want >= %v", got, pollFloor)
+	}
+}
+
+func TestPollStopsWhenDone(t *testing.T) {
+	b := Backoff{Initial: time.Millisecond, Max: time.Millisecond, Factor: 1}
+	calls := 0
+	err := Poll(context.Background(), b, func(context.Context) (bool, error) {
+		calls++
+		return calls == 3, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("probe called %d times, want 3", calls)
+	}
+}
+
+func TestPollProbesImmediately(t *testing.T) {
+	// First probe must run with no initial delay.
+	b := Backoff{Initial: time.Hour, Max: time.Hour, Factor: 1}
+	err := Poll(context.Background(), b, func(context.Context) (bool, error) {
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPollPropagatesProbeError(t *testing.T) {
+	sentinel := errors.New("boom")
+	b := Backoff{Initial: time.Millisecond, Max: time.Millisecond, Factor: 1}
+	err := Poll(context.Background(), b, func(context.Context) (bool, error) {
+		return false, sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("got %v, want %v", err, sentinel)
+	}
+}
+
+func TestPollTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	b := Backoff{Initial: 5 * time.Millisecond, Max: 5 * time.Millisecond, Factor: 1}
+	err := Poll(ctx, b, func(context.Context) (bool, error) {
+		return false, nil // never done
+	})
+	if !errors.Is(err, ErrTimeout) {
+		t.Errorf("got %v, want ErrTimeout", err)
+	}
+}
+
+func TestPollCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	b := Backoff{Initial: 5 * time.Millisecond, Max: 5 * time.Millisecond, Factor: 1}
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+	err := Poll(ctx, b, func(context.Context) (bool, error) {
+		return false, nil
+	})
+	if !errors.Is(err, ErrCanceled) {
+		t.Errorf("got %v, want ErrCanceled", err)
+	}
+}
+
+func TestServerStatusNilSafe(t *testing.T) {
+	if serverStatus(nil) != nil {
+		t.Error("serverStatus(nil) should be nil")
+	}
+	if serverStatus(&operations.GetServerResponse{}) != nil {
+		t.Error("serverStatus with nil Server should be nil")
+	}
+	on := components.ServerDataStatusOn
+	resp := &operations.GetServerResponse{
+		Server: &components.Server{
+			Data: &components.ServerData{
+				Attributes: &components.ServerDataAttributes{Status: &on},
+			},
+		},
+	}
+	got := serverStatus(resp)
+	if got == nil || *got != components.ServerDataStatusOn {
+		t.Errorf("serverStatus = %v, want on", got)
+	}
+}
+
+func TestContainsStatus(t *testing.T) {
+	set := []components.ServerDataStatus{
+		components.ServerDataStatusOn,
+		components.ServerDataStatusDeploying,
+	}
+	if !containsStatus(set, components.ServerDataStatusOn) {
+		t.Error("expected on to be in set")
+	}
+	if containsStatus(set, components.ServerDataStatusOff) {
+		t.Error("did not expect off to be in set")
+	}
+}
+
+func TestDecideServerState(t *testing.T) {
+	want := []components.ServerDataStatus{components.ServerDataStatusOn, components.ServerDataStatusOff}
+	fail := []components.ServerDataStatus{components.ServerDataStatusFailedDeployment}
+
+	t.Run("want hit without requireTransition is done", func(t *testing.T) {
+		done, _, err := decideServerState(components.ServerDataStatusOn, want, fail, false, false)
+		if err != nil || !done {
+			t.Fatalf("done=%v err=%v, want done=true err=nil", done, err)
+		}
+	})
+
+	t.Run("want hit is gated until a transition is seen", func(t *testing.T) {
+		done, transitioned, err := decideServerState(components.ServerDataStatusOn, want, fail, true, false)
+		if err != nil || done {
+			t.Fatalf("done=%v err=%v, want done=false err=nil (gated)", done, err)
+		}
+		if transitioned {
+			t.Error("a target state should not count as a transition")
+		}
+	})
+
+	t.Run("transition state flips seenTransition then want succeeds", func(t *testing.T) {
+		_, transitioned, _ := decideServerState(components.ServerDataStatusDeploying, want, fail, true, false)
+		if !transitioned {
+			t.Fatal("deploying should set seenTransition")
+		}
+		done, _, err := decideServerState(components.ServerDataStatusOn, want, fail, true, transitioned)
+		if err != nil || !done {
+			t.Fatalf("done=%v err=%v, want done=true after transition", done, err)
+		}
+	})
+
+	t.Run("fail state reported immediately even without transition (H1 regression)", func(t *testing.T) {
+		done, _, err := decideServerState(components.ServerDataStatusFailedDeployment, want, fail, true, false)
+		if done {
+			t.Error("fail state must not be 'done'")
+		}
+		if !errors.Is(err, ErrFailedState) {
+			t.Errorf("got %v, want ErrFailedState", err)
+		}
+	})
+}
+
+func TestIsTerminalAPIError(t *testing.T) {
+	cases := []struct {
+		code int
+		want bool
+	}{
+		{404, true},
+		{401, true},
+		{403, true},
+		{422, true},
+		{408, false}, // request timeout: transient
+		{425, false}, // too early: transient
+		{429, false}, // rate-limited: transient
+		{500, false},
+		{503, false},
+	}
+	for _, c := range cases {
+		err := components.NewAPIError("x", c.code, "", nil)
+		if got := isTerminalAPIError(err); got != c.want {
+			t.Errorf("status %d: got %v, want %v", c.code, got, c.want)
+		}
+	}
+	if isTerminalAPIError(errors.New("plain")) {
+		t.Error("a non-API error should not be terminal")
+	}
+}


### PR DESCRIPTION
## Summary

Adds the PD-6073 automation primitives so scripts can wait for resource transitions and tail events without hand-rolled polling loops.

- **`internal/wait/`** — reusable polling infrastructure shared by `--wait` and `--follow`: a context-aware `Poll` loop with bounded backoff (never faster than 1 req/s), `SignalContext` for clean Ctrl+C, the `--wait`/`--timeout` flag pair, and `ForServerState` for server state-machine waits.
- **`--wait` / `--timeout` on `servers create` and `servers reinstall`** — blocks until the server settles into a stable state (`on`/`off`), fails fast on `failed_deployment`, and exits non-zero on timeout. A `requireTransition` guard avoids accepting a state the server was already in before the operation started. Progress goes to stderr; the real final state is re-fetched and rendered to stdout (honoring `-o json/yaml/csv`), so the optimistic POST snapshot never misleads.
- **`events list --follow`** — streams new events by advancing an inclusive, second-granular `created_at` cursor, de-duplicating by event ID (with a synthetic key fallback) so nothing is reprinted. Clean Ctrl+C, ≤1 req/s steady state, ≤5s freshness. `--follow` is plain-text only; a structured `-o` flag is ignored with an explicit stderr warning.
- **`renderer.RenderStatic`** — non-interactive render path so `--wait` progress output and the final table don't collide with the Bubble Tea view.

`events list` and its filters already shipped earlier; this PR adds `--follow` on top.

## Acceptance criteria

- [x] `servers create … --wait` returns only when the server is fully provisioned
- [x] `servers create … --wait --timeout 30s` exits non-zero on timeout
- [x] `events list --target-id sv_xxx` filters correctly (pre-existing)
- [x] `events list --follow` prints new events as they happen (≤5s)
- [x] Ctrl+C on `--follow` exits cleanly, no traceback
- [x] Polling backoff stays ≤1 req/s in steady state
- [x] Reusable polling infra in `internal/wait/` shared by both features

> Note: `servers actions … --action reboot --wait` is intentionally deferred — the `actions` command itself is created in PD-6075; this PR provides the `wait` infrastructure it will consume.

## Testing

```bash
go test ./...
```

Manual:
```bash
lsh servers create --project=<p> --site=<s> --plan=<plan> \
  --operating_system=<os> --hostname=test --wait --no-input
lsh servers create ... --wait --timeout 30s   # exit != 0 on timeout
lsh events list --follow                       # Ctrl+C exits cleanly
lsh events list --follow -o json               # warns: plain-text only
```

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces `--wait`/`--timeout` flags for `servers create` and `servers reinstall`, and a `--follow` streaming mode for `events list`, backed by a new reusable `internal/wait/` package with bounded backoff, signal-aware context, and a `requireTransition` guard.

- **`internal/wait/`**: Context-aware `Poll` loop with a 1 req/s floor, `ForServerState` with correct transient-vs-terminal API error discrimination (`isTerminalAPIError`), and sentinel errors (`ErrTimeout`, `ErrCanceled`, `ErrFailedState`) for clean caller dispatch.
- **`--wait` on `servers create`/`reinstall`**: Suppresses the optimistic POST snapshot, polls until a stable state (`on`/`off`) or `failed_deployment`, then re-fetches and renders the real final state via `RenderStatic`.
- **`events list --follow`**: Inclusive second-granular cursor advancing with event-ID-based dedup, explicit warnings for incompatible flags (`-o`, `--until`), and a `maxUndated` cap against unbounded map growth on long-running sessions.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one fix recommended: the --follow poll loop swallows all API errors including non-retryable ones.

The wait infrastructure in `internal/wait/` is well-designed and correctly distinguishes terminal from transient API errors in `ForServerState`. The same discipline is not applied in `followEvents`: a 401 (expired token), 403, or 404 returned by `client.Events.List` is printed as a warning and retried forever, rather than surfacing as a clean failure. On a long-running `--follow` session with an expired credential, the user will see a warning line every 1–5 seconds with no actionable guidance and no way out except Ctrl+C. Everything else — the backoff, the deduper, the `requireTransition` guard, the `RenderStatic` path — is solid.

cmd/events/list.go (the followEvents error-handling path, lines 505–509)
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `cmd/events/list.go`, line 55-68 ([link](https://github.com/latitudesh/cli/blob/ba287b9f4b44cdae4860976b3791c5f2e8dde1d5/cmd/events/list.go#L55-L68)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Two separate `time.Now()` calls for the same logical reference point**

   `buildEventsRequest` and `followEvents` each call `time.Now()` independently. When `--since` is absent the second call is the one that seeds the follow cursor, so there's no functional issue in practice (both truncate to the same second). But capturing `now` once and threading it through makes the intent clearer and prevents any theoretical skew if command startup is slow.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: cmd/events/list.go
   Line: 55-68

   Comment:
   **Two separate `time.Now()` calls for the same logical reference point**

   `buildEventsRequest` and `followEvents` each call `time.Now()` independently. When `--since` is absent the second call is the one that seeds the follow cursor, so there's no functional issue in practice (both truncate to the same second). But capturing `now` once and threading it through makes the intent clearer and prevents any theoretical skew if command startup is slow.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

2. `cmd/events/list.go`, line 505-509 ([link](https://github.com/latitudesh/cli/blob/5be04bd80efa034d32d863cc29d485e40424b0a8/cmd/events/list.go#L505-L509)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Terminal API errors swallowed indefinitely in `--follow`**

   `followEvents` treats every API error — including non-retryable 4xx responses like 401 (token expired), 403 (forbidden), or 404 (endpoint gone) — the same as a transient network blip. On a long-running session where the API key expires, the user will get a `"warning: events poll failed: 401 Unauthorized"` line every 1–5 seconds with no way to escape short of Ctrl+C, and no actionable message.

   `ForServerState` in `internal/wait/server.go` already has the right pattern for this: it calls `isTerminalAPIError(err)` and fast-fails on 4xx errors that can't self-heal. `followEvents` should apply the same (or a simplified equivalent) check — return the error from the probe so `Poll` propagates it instead of swallowing it.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: cmd/events/list.go
   Line: 505-509

   Comment:
   **Terminal API errors swallowed indefinitely in `--follow`**

   `followEvents` treats every API error — including non-retryable 4xx responses like 401 (token expired), 403 (forbidden), or 404 (endpoint gone) — the same as a transient network blip. On a long-running session where the API key expires, the user will get a `"warning: events poll failed: 401 Unauthorized"` line every 1–5 seconds with no way to escape short of Ctrl+C, and no actionable message.

   `ForServerState` in `internal/wait/server.go` already has the right pattern for this: it calls `isTerminalAPIError(err)` and fast-fails on 4xx errors that can't self-heal. `followEvents` should apply the same (or a simplified equivalent) check — return the error from the probe so `Poll` propagates it instead of swallowing it.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
cmd/events/list.go:505-509
**Terminal API errors swallowed indefinitely in `--follow`**

`followEvents` treats every API error — including non-retryable 4xx responses like 401 (token expired), 403 (forbidden), or 404 (endpoint gone) — the same as a transient network blip. On a long-running session where the API key expires, the user will get a `"warning: events poll failed: 401 Unauthorized"` line every 1–5 seconds with no way to escape short of Ctrl+C, and no actionable message.

`ForServerState` in `internal/wait/server.go` already has the right pattern for this: it calls `isTerminalAPIError(err)` and fast-fails on 4xx errors that can't self-heal. `followEvents` should apply the same (or a simplified equivalent) check — return the error from the probe so `Poll` propagates it instead of swallowing it.

### Issue 2 of 2
cli/create_server_operation.go:170-179
**No output rendered when `--wait` is set but server ID cannot be extracted**

When `--wait` is enabled, the optimistic create response is intentionally suppressed (the `!waitOpts.Enabled` guard on line 170 skips `utils.Render`). If `response.GetPayload()` is nil or `p.Data` is nil — causing `serverID` to be empty — `waitForServerState` warns and returns nil. The user then exits with code 0 and **zero stdout output**: no server ID, no IP, no table row — just a stderr warning about `--wait` being ignored.

The fallback should render the create response when `serverID` can't be determined, so the user at least sees what was provisioned before the wait was skipped.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(cli): add --wait, events --follow a..."](https://github.com/latitudesh/cli/commit/5be04bd80efa034d32d863cc29d485e40424b0a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38570677)</sub>

<!-- /greptile_comment -->