### PR TITLE
feat(cli): add server power, rescue and lock commands (PD-6075)

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/latitudesh/lsh/client"
 	"github.com/latitudesh/lsh/cmd/lsh"
+	servers "github.com/latitudesh/lsh/cmd/servers"
 	"github.com/latitudesh/lsh/internal/pagination"
 	"github.com/latitudesh/lsh/internal/renderer"
 	"github.com/latitudesh/lsh/internal/version"
@@ -458,6 +459,15 @@ func makeOperationGroupServersCmd() (*cobra.Command, error) {
 		return nil, err
 	}
 	operationGroupServersCmd.AddCommand(operationServerReinstallCmd)
+
+	// PD-6075: SDK-backed server extensions.
+	operationGroupServersCmd.AddCommand(servers.NewPowerOnCmd())
+	operationGroupServersCmd.AddCommand(servers.NewPowerOffCmd())
+	operationGroupServersCmd.AddCommand(servers.NewRebootCmd())
+	operationGroupServersCmd.AddCommand(servers.NewRescueModeCmd())
+	operationGroupServersCmd.AddCommand(servers.NewExitRescueModeCmd())
+	operationGroupServersCmd.AddCommand(servers.NewLockCmd())
+	operationGroupServersCmd.AddCommand(servers.NewUnlockCmd())
 
 	return operationGroupServersCmd, nil
 }

--- a/cmd/servers/actions.go
+++ b/cmd/servers/actions.go
@@ -1,0 +1,124 @@
+package servers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
+	"github.com/latitudesh/lsh/cmd/lsh"
+	"github.com/latitudesh/lsh/internal/utils"
+	"github.com/latitudesh/lsh/internal/wait"
+	cobra "github.com/spf13/cobra"
+)
+
+// validActions maps a CLI power-action name to the SDK enum accepted by
+// POST /servers/{id}/actions.
+var validActions = map[string]operations.CreateServerActionAction{
+	"power_on":  operations.CreateServerActionActionPowerOn,
+	"power_off": operations.CreateServerActionActionPowerOff,
+	"reboot":    operations.CreateServerActionActionReboot,
+}
+
+// newPowerActionCmd builds a `lsh servers <use> <server_id>` command that runs a
+// single power action, following the gcloud/doctl convention of a dedicated
+// subcommand per action instead of a generic `actions --action <name>`.
+func newPowerActionCmd(use, short, long, example, action string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     use + " <server_id>",
+		Short:   short,
+		Long:    long,
+		Example: example,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPowerAction(cmd, args[0], action)
+		},
+	}
+	wait.AddFlags(cmd)
+	return cmd
+}
+
+// NewPowerOnCmd builds `lsh servers power-on <server_id>`.
+func NewPowerOnCmd() *cobra.Command {
+	return newPowerActionCmd(
+		"power-on",
+		"Power on a server",
+		"Power on a server.\n\nWith --wait the command blocks until the server is on.",
+		`  lsh servers power-on sv_xxxxxxxx
+  lsh servers power-on sv_xxxxxxxx --wait`,
+		"power_on",
+	)
+}
+
+// NewPowerOffCmd builds `lsh servers power-off <server_id>`.
+func NewPowerOffCmd() *cobra.Command {
+	return newPowerActionCmd(
+		"power-off",
+		"Power off a server",
+		"Power off a server.\n\nWith --wait the command blocks until the server is off.",
+		`  lsh servers power-off sv_xxxxxxxx
+  lsh servers power-off sv_xxxxxxxx --wait`,
+		"power_off",
+	)
+}
+
+// NewRebootCmd builds `lsh servers reboot <server_id>`.
+func NewRebootCmd() *cobra.Command {
+	return newPowerActionCmd(
+		"reboot",
+		"Reboot a server",
+		"Reboot a server.\n\nWith --wait the command blocks until the server is back on.",
+		`  lsh servers reboot sv_xxxxxxxx
+  lsh servers reboot sv_xxxxxxxx --wait`,
+		"reboot",
+	)
+}
+
+// runPowerAction sends the power action to the API and, unless --wait is set,
+// renders the result statically. With --wait it blocks until the server reaches
+// the expected power state.
+func runPowerAction(cmd *cobra.Command, serverID, action string) error {
+	sdkAction, ok := validActions[action]
+	if !ok {
+		err := fmt.Errorf("unknown power action %q", action)
+		utils.PrintError(err)
+		return err
+	}
+
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip sending request.")
+		return nil
+	}
+
+	client := lsh.NewClient()
+	ctx := context.Background()
+
+	requestBody := operations.CreateServerActionServersRequestBody{
+		Data: operations.CreateServerActionServersData{
+			Type: operations.CreateServerActionServersTypeActions,
+			Attributes: &operations.CreateServerActionServersAttributes{
+				Action: sdkAction,
+			},
+		},
+	}
+
+	response, err := client.Servers.RunAction(ctx, serverID, requestBody, operations.WithRetries(lsh.RetryConfig()))
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	waitEnabled := wait.OptionsFrom(cmd).Enabled
+	if !lsh.Debug && !waitEnabled {
+		data := &ServerActionModel{ServerID: serverID, Action: action}
+		if response.ServerAction != nil {
+			data.Data = response.ServerAction.Data
+		}
+		utils.RenderStatic(data.GetData())
+	}
+
+	want, fail := powerActionTargets(action)
+	// Only reboot must observe a transition (the server is "on" before and
+	// after); power_on/power_off on a server already in the target state are
+	// already done, and requiring a transition would hang until timeout.
+	return waitForServerState(cmd, serverID, want, fail, action == "reboot")
+}

--- a/cmd/servers/lock.go
+++ b/cmd/servers/lock.go
@@ -2,16 +2,12 @@ package servers
 
 import (
 	"context"
-	"errors"
 
 	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
 	"github.com/latitudesh/lsh/cmd/lsh"
 	"github.com/latitudesh/lsh/internal/utils"
 	cobra "github.com/spf13/cobra"
 )
-
-// errNoFlags is returned by update-style commands invoked with no changes.
-var errNoFlags = errors.New("no fields to update: pass at least one flag")
 
 // NewLockCmd builds `lsh servers lock <id>`.
 func NewLockCmd() *cobra.Command {

--- a/cmd/servers/lock.go
+++ b/cmd/servers/lock.go
@@ -1,0 +1,84 @@
+package servers
+
+import (
+	"context"
+	"errors"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
+	"github.com/latitudesh/lsh/cmd/lsh"
+	"github.com/latitudesh/lsh/internal/utils"
+	cobra "github.com/spf13/cobra"
+)
+
+// errNoFlags is returned by update-style commands invoked with no changes.
+var errNoFlags = errors.New("no fields to update: pass at least one flag")
+
+// NewLockCmd builds `lsh servers lock <id>`.
+func NewLockCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "lock <server_id>",
+		Short:   "Lock a server",
+		Long:    "Lock a server to prevent destructive actions (deletion, reinstall, power changes).",
+		Example: `  lsh servers lock sv_xxxxxxxx`,
+		Args:    cobra.ExactArgs(1),
+		RunE:    runLock,
+	}
+}
+
+func runLock(cmd *cobra.Command, args []string) error {
+	serverID := args[0]
+
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip sending request.")
+		return nil
+	}
+
+	client := lsh.NewClient()
+	ctx := context.Background()
+
+	if _, err := client.Servers.Lock(ctx, serverID, operations.WithRetries(lsh.RetryConfig())); err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	if !lsh.Debug {
+		model := &SimpleServerModel{ServerID: serverID, State: "locked"}
+		utils.RenderStatic(model.GetData())
+	}
+	return nil
+}
+
+// NewUnlockCmd builds `lsh servers unlock <id>`.
+func NewUnlockCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "unlock <server_id>",
+		Short:   "Unlock a server",
+		Long:    "Unlock a server to allow destructive actions again.",
+		Example: `  lsh servers unlock sv_xxxxxxxx`,
+		Args:    cobra.ExactArgs(1),
+		RunE:    runUnlock,
+	}
+}
+
+func runUnlock(cmd *cobra.Command, args []string) error {
+	serverID := args[0]
+
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip sending request.")
+		return nil
+	}
+
+	client := lsh.NewClient()
+	ctx := context.Background()
+
+	if _, err := client.Servers.Unlock(ctx, serverID, operations.WithRetries(lsh.RetryConfig())); err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	if !lsh.Debug {
+		model := &SimpleServerModel{ServerID: serverID, State: "unlocked"}
+		utils.RenderStatic(model.GetData())
+	}
+	return nil
+}

--- a/cmd/servers/rescue.go
+++ b/cmd/servers/rescue.go
@@ -1,0 +1,115 @@
+package servers
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
+	"github.com/latitudesh/lsh/cmd/lsh"
+	"github.com/latitudesh/lsh/internal/utils"
+	"github.com/latitudesh/lsh/internal/wait"
+	cobra "github.com/spf13/cobra"
+)
+
+// NewRescueModeCmd builds `lsh servers rescue-mode <id>`.
+func NewRescueModeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rescue-mode <server_id>",
+		Short: "Boot a server into rescue mode",
+		Long: "Reboot a server into rescue mode.\n\n" +
+			"With --wait the command blocks until the server settles into the\n" +
+			"rescue_mode state.\n\n" +
+			"The rescue login credentials are not exposed by the API; retrieve them\n" +
+			"on the server's page in the dashboard.",
+		Example: `  lsh servers rescue-mode sv_xxxxxxxx
+  lsh servers rescue-mode sv_xxxxxxxx --wait`,
+		Args: cobra.ExactArgs(1),
+		RunE: runRescueMode,
+	}
+	wait.AddFlags(cmd)
+	return cmd
+}
+
+func runRescueMode(cmd *cobra.Command, args []string) error {
+	serverID := args[0]
+
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip sending request.")
+		return nil
+	}
+
+	client := lsh.NewClient()
+	ctx := context.Background()
+
+	if _, err := client.Servers.StartRescueMode(ctx, serverID, operations.WithRetries(lsh.RetryConfig())); err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	waitEnabled := wait.OptionsFrom(cmd).Enabled
+	if !lsh.Debug && !waitEnabled {
+		model := &SimpleServerModel{ServerID: serverID, State: "rescue mode requested"}
+		utils.RenderStatic(model.GetData())
+	}
+	// The API does not expose the rescue credentials; point the user at the
+	// dashboard. stderr keeps stdout clean for structured output.
+	fmt.Fprintln(os.Stderr, "Note: rescue login credentials are available on the server's page in the dashboard.")
+
+	want := []components.ServerDataStatus{components.ServerDataStatusRescueMode}
+	fail := []components.ServerDataStatus{components.ServerDataStatusFailedDeployment}
+	// Idempotent wait: a server already in the target state is already done —
+	// requiring a transition here would hang until timeout.
+	return waitForServerState(cmd, serverID, want, fail, false)
+}
+
+// NewExitRescueModeCmd builds `lsh servers exit-rescue-mode <id>`.
+func NewExitRescueModeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "exit-rescue-mode <server_id>",
+		Short: "Exit rescue mode on a server",
+		Long: "Reboot a server out of rescue mode into its normal operating system.\n\n" +
+			"With --wait the command blocks until the server settles into a stable\n" +
+			"power state (on/off).",
+		Example: `  lsh servers exit-rescue-mode sv_xxxxxxxx
+  lsh servers exit-rescue-mode sv_xxxxxxxx --wait`,
+		Args: cobra.ExactArgs(1),
+		RunE: runExitRescueMode,
+	}
+	wait.AddFlags(cmd)
+	return cmd
+}
+
+func runExitRescueMode(cmd *cobra.Command, args []string) error {
+	serverID := args[0]
+
+	if lsh.DryRun {
+		lsh.LogDebugf("dry-run flag specified. Skip sending request.")
+		return nil
+	}
+
+	client := lsh.NewClient()
+	ctx := context.Background()
+
+	if _, err := client.Servers.ExitRescueMode(ctx, serverID, operations.WithRetries(lsh.RetryConfig())); err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	waitEnabled := wait.OptionsFrom(cmd).Enabled
+	if !lsh.Debug && !waitEnabled {
+		model := &SimpleServerModel{ServerID: serverID, State: "exit rescue mode requested"}
+		utils.RenderStatic(model.GetData())
+	}
+
+	// Leaving rescue mode reboots into the installed OS; it settles on/off.
+	want := []components.ServerDataStatus{
+		components.ServerDataStatusOn,
+		components.ServerDataStatusOff,
+	}
+	fail := []components.ServerDataStatus{components.ServerDataStatusFailedDeployment}
+	// Idempotent wait: a server already in the target state is already done —
+	// requiring a transition here would hang until timeout.
+	return waitForServerState(cmd, serverID, want, fail, false)
+}

--- a/cmd/servers/servers.go
+++ b/cmd/servers/servers.go
@@ -1,0 +1,64 @@
+// Package servers holds the SDK-backed server subcommands added for PD-6075:
+// power actions, rescue mode and lock/unlock
+// access. Each command talks to the API through lsh.NewClient() and renders
+// through the shared renderer so -o json/yaml and --query work everywhere.
+package servers
+
+import (
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+	"github.com/latitudesh/lsh/internal/output/table"
+	"github.com/latitudesh/lsh/internal/renderer"
+)
+
+// getStr safely dereferences an optional string pointer.
+func getStr(s *string) string {
+	if s != nil {
+		return *s
+	}
+	return ""
+}
+
+// ServerActionModel renders the response of a server power action.
+type ServerActionModel struct {
+	ServerID string
+	Action   string
+	Data     *components.ServerActionData
+}
+
+func (m *ServerActionModel) GetData() []renderer.ResponseData {
+	return []renderer.ResponseData{m}
+}
+
+func (m *ServerActionModel) TableRow() table.Row {
+	var id, status string
+	if m.Data != nil {
+		id = getStr(m.Data.ID)
+		if m.Data.Attributes != nil {
+			status = getStr(m.Data.Attributes.Status)
+		}
+	}
+	return table.Row{
+		"server_id": table.Cell{Label: "Server ID", Value: table.String(m.ServerID)},
+		"action":    table.Cell{Label: "Action", Value: table.String(m.Action)},
+		"id":        table.Cell{Label: "Action ID", Value: table.String(id)},
+		"status":    table.Cell{Label: "Status", Value: table.String(status)},
+	}
+}
+
+// SimpleServerModel renders a one-line outcome for state changes (lock/unlock,
+// rescue mode) that return no body of their own.
+type SimpleServerModel struct {
+	ServerID string
+	State    string
+}
+
+func (m *SimpleServerModel) GetData() []renderer.ResponseData {
+	return []renderer.ResponseData{m}
+}
+
+func (m *SimpleServerModel) TableRow() table.Row {
+	return table.Row{
+		"server_id": table.Cell{Label: "Server ID", Value: table.String(m.ServerID)},
+		"state":     table.Cell{Label: "State", Value: table.String(m.State)},
+	}
+}

--- a/cmd/servers/servers_test.go
+++ b/cmd/servers/servers_test.go
@@ -1,0 +1,108 @@
+package servers
+
+import (
+	"testing"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
+)
+
+func strp(s string) *string { return &s }
+
+// TestActionsFlagParsing pins the action → SDK enum mapping and rejects
+// invalid actions.
+func TestActionsFlagParsing(t *testing.T) {
+	cases := map[string]struct {
+		want operations.CreateServerActionAction
+		ok   bool
+	}{
+		"power_on":  {operations.CreateServerActionActionPowerOn, true},
+		"power_off": {operations.CreateServerActionActionPowerOff, true},
+		"reboot":    {operations.CreateServerActionActionReboot, true},
+		"bogus":     {"", false},
+	}
+	for action, want := range cases {
+		got, ok := validActions[action]
+		if ok != want.ok {
+			t.Errorf("validActions[%q] ok = %v, want %v", action, ok, want.ok)
+		}
+		if ok && got != want.want {
+			t.Errorf("validActions[%q] = %v, want %v", action, got, want.want)
+		}
+	}
+}
+
+func TestActionsCmdRequiresArg(t *testing.T) {
+	cmd := NewRebootCmd()
+	if cmd.Args == nil {
+		t.Fatal("expected ExactArgs validator on power action command")
+	}
+	if err := cmd.Args(cmd, []string{}); err == nil {
+		t.Error("expected error with no server ID, got nil")
+	}
+	if err := cmd.Args(cmd, []string{"sv_x"}); err != nil {
+		t.Errorf("expected no error with one server ID, got %v", err)
+	}
+}
+
+// TestPowerActionTargets verifies each action waits for the correct terminal
+// power state.
+func TestPowerActionTargets(t *testing.T) {
+	cases := map[string]components.ServerDataStatus{
+		"power_on":  components.ServerDataStatusOn,
+		"reboot":    components.ServerDataStatusOn,
+		"power_off": components.ServerDataStatusOff,
+	}
+	for action, wantState := range cases {
+		want, fail := powerActionTargets(action)
+		if len(want) != 1 || want[0] != wantState {
+			t.Errorf("powerActionTargets(%q) want = %v, expected [%v]", action, want, wantState)
+		}
+		if len(fail) != 1 || fail[0] != components.ServerDataStatusFailedDeployment {
+			t.Errorf("powerActionTargets(%q) fail = %v, expected [failed_deployment]", action, fail)
+		}
+	}
+}
+
+// TestServerActionModelTableRow pins the rendered columns of a power action.
+func TestServerActionModelTableRow(t *testing.T) {
+	model := &ServerActionModel{
+		ServerID: "sv_x",
+		Action:   "reboot",
+		Data: &components.ServerActionData{
+			ID:         strp("act_1"),
+			Attributes: &components.ServerActionAttributes{Status: strp("queued")},
+		},
+	}
+	row := model.TableRow()
+	expect := map[string]string{
+		"server_id": "sv_x",
+		"action":    "reboot",
+		"id":        "act_1",
+		"status":    "queued",
+	}
+	for k, want := range expect {
+		if got := row[k].Value; got != want {
+			t.Errorf("row[%q] = %q, want %q", k, got, want)
+		}
+	}
+}
+
+// TestWaitFlagsRegistered ensures --wait/--timeout are present on the commands
+// that should support waiting.
+func TestWaitFlagsRegistered(t *testing.T) {
+	// Commands that must support waiting.
+	if NewRebootCmd().Flags().Lookup("wait") == nil {
+		t.Error("reboot: missing --wait flag")
+	}
+	if NewRescueModeCmd().Flags().Lookup("wait") == nil {
+		t.Error("rescue-mode: missing --wait flag")
+	}
+	if NewExitRescueModeCmd().Flags().Lookup("wait") == nil {
+		t.Error("exit-rescue-mode: missing --wait flag")
+	}
+	// Commands that must NOT have --wait.
+	if NewLockCmd().Flags().Lookup("wait") != nil {
+		t.Error("lock: unexpected --wait flag")
+	}
+}

--- a/cmd/servers/servers_test.go
+++ b/cmd/servers/servers_test.go
@@ -95,6 +95,12 @@ func TestWaitFlagsRegistered(t *testing.T) {
 	if NewRebootCmd().Flags().Lookup("wait") == nil {
 		t.Error("reboot: missing --wait flag")
 	}
+	if NewPowerOnCmd().Flags().Lookup("wait") == nil {
+		t.Error("power-on: missing --wait flag")
+	}
+	if NewPowerOffCmd().Flags().Lookup("wait") == nil {
+		t.Error("power-off: missing --wait flag")
+	}
 	if NewRescueModeCmd().Flags().Lookup("wait") == nil {
 		t.Error("rescue-mode: missing --wait flag")
 	}

--- a/cmd/servers/wait.go
+++ b/cmd/servers/wait.go
@@ -1,0 +1,71 @@
+package servers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/latitudesh/latitudesh-go-sdk/models/components"
+	"github.com/latitudesh/latitudesh-go-sdk/models/operations"
+	"github.com/latitudesh/lsh/cmd/lsh"
+	"github.com/latitudesh/lsh/internal/wait"
+	"github.com/spf13/cobra"
+)
+
+// waitForServerState blocks until the server reaches one of want, hits one of
+// fail, times out, or the user cancels — but only when --wait was passed. All
+// progress is written to stderr so it never corrupts structured (-o json)
+// output on stdout.
+//
+// requireTransition guards operations that act on a server which may already
+// sit in a target state (e.g. power_on on an already-on server) so the wait
+// does not return before the operation has actually taken effect.
+func waitForServerState(cmd *cobra.Command, serverID string, want, fail []components.ServerDataStatus, requireTransition bool) error {
+	o := wait.OptionsFrom(cmd)
+	if !o.Enabled {
+		if cmd.Flags().Changed("timeout") {
+			fmt.Fprintln(os.Stderr, "warning: --timeout has no effect without --wait")
+		}
+		return nil
+	}
+	if serverID == "" {
+		fmt.Fprintln(os.Stderr, "warning: --wait ignored: could not determine the server ID")
+		return nil
+	}
+
+	client := lsh.NewClient()
+	ctx, cancel := wait.SignalContext(context.Background())
+	defer cancel()
+
+	fmt.Fprintf(os.Stderr, "Waiting for server %s to reach its target state… (Ctrl+C to stop)\n", serverID)
+
+	status, err := wait.ForServerState(ctx, client, serverID, want, fail, requireTransition, o, nil, operations.WithRetries(lsh.RetryConfig()))
+	switch {
+	case errors.Is(err, wait.ErrCanceled):
+		return fmt.Errorf("wait canceled (last status: %s)", status)
+	case errors.Is(err, wait.ErrTimeout):
+		return fmt.Errorf("timed out waiting for server %s (last status: %s)", serverID, status)
+	case errors.Is(err, wait.ErrFailedState):
+		return fmt.Errorf("server %s entered a failed state: %s", serverID, status)
+	case err != nil:
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "Server %s is now %q\n", serverID, status)
+	return nil
+}
+
+// powerActionTargets maps a power action to the server states that satisfy the
+// wait (want) and the states that abort it (fail).
+func powerActionTargets(action string) (want, fail []components.ServerDataStatus) {
+	fail = []components.ServerDataStatus{components.ServerDataStatusFailedDeployment}
+	switch action {
+	case "power_on", "reboot":
+		return []components.ServerDataStatus{components.ServerDataStatusOn}, fail
+	case "power_off":
+		return []components.ServerDataStatus{components.ServerDataStatusOff}, fail
+	default:
+		return nil, fail
+	}
+}


### PR DESCRIPTION
### Summary

Adds SDK-backed server management commands, closing the reworked scope of PD-6075.

- `lsh servers power-on | power-off | reboot <server_id>` — one subcommand per power action (gcloud/doctl convention), with `--wait`
- `lsh servers rescue-mode | exit-rescue-mode <server_id>` — with `--wait`
- `lsh servers lock | unlock <server_id>`
- `--wait` semantics: idempotent for rescue/power-on/power-off (a server already in the target state completes immediately); `reboot` requires observing the power cycle
- Mutations render flat output; all commands honor `-o json/yaml/csv`, `--query` and `--profile`

**Known limitations**
- The API does not expose rescue login credentials; `rescue-mode` prints a stderr hint pointing to the server's page in the dashboard
- `deploy-config`, `remote-access` and the `plans` sub-listings were descoped from this card (pending spec/SDK fixes)

### Testing

**Clone & checkout**
```bash
git clone https://github.com/latitudesh/cli.git && cd cli
git checkout PD-6075-cli-servers-plans-extensions
```

**Build & unit tests**
```bash
go build -o lsh .
go test ./...
```

**Try the commands** (requires an authenticated profile — `./lsh login`)
```bash
# power actions
./lsh servers reboot <sv_id> --wait
./lsh servers power-off <sv_id> --wait
./lsh servers power-on <sv_id> --wait

# rescue mode (credentials on the server's dashboard page)
./lsh servers rescue-mode <sv_id> --wait
./lsh servers exit-rescue-mode <sv_id> --wait

# lock / unlock
./lsh servers lock <sv_id>
./lsh servers unlock <sv_id>

# structured output
./lsh servers reboot <sv_id> -o json
```

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds SDK-backed server management commands for power actions (`power-on`, `power-off`, `reboot`), rescue mode (`rescue-mode`, `exit-rescue-mode`), and lock/unlock, wired into the existing cobra command tree in `cli/cli.go`.

- Power and rescue commands support a `--wait`/`--timeout` flag pair that polls `GET /servers/{id}` with exponential backoff, using `requireTransition=true` for `reboot` (which must observe a state change) and `false` for idempotent actions already at the target state.
- Lock/unlock commands produce a synthetic `SimpleServerModel` output since their API calls return no meaningful body; rescue-mode additionally prints a stderr hint directing users to the dashboard for credentials (not exposed by the API).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. All seven new subcommands are isolated additions; no existing code paths are modified.

The wait loop, error classification, and nil-guarded model rendering are all handled correctly. The only gaps are a minor test asymmetry for unlock and a stale word in the package doc comment.

No files require special attention.
</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant CLI as cobra Command
    participant API as Latitude API
    participant Poller as wait.ForServerState

    User->>CLI: lsh servers reboot sv_x [--wait]
    CLI->>CLI: validate action via validActions map
    CLI->>API: POST /servers/sv_x/actions
    API-->>CLI: ServerAction response

    alt --wait NOT set
        CLI->>User: stdout table/json
        CLI->>CLI: waitForServerState returns nil immediately
    else --wait set
        CLI->>User: stderr: Waiting for server sv_x
        CLI->>Poller: "ForServerState(want=[on], requireTransition=true)"
        loop poll every 2-15s
            Poller->>API: GET /servers/sv_x
            API-->>Poller: status
            alt "status==on and transition observed"
                Poller-->>CLI: success
            else "status==failed_deployment"
                Poller-->>CLI: ErrFailedState
            else timeout or cancel
                Poller-->>CLI: ErrTimeout/ErrCanceled
            end
        end
        CLI->>User: stderr: Server sv_x is now on
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant CLI as cobra Command
    participant API as Latitude API
    participant Poller as wait.ForServerState

    User->>CLI: lsh servers reboot sv_x [--wait]
    CLI->>CLI: validate action via validActions map
    CLI->>API: POST /servers/sv_x/actions
    API-->>CLI: ServerAction response

    alt --wait NOT set
        CLI->>User: stdout table/json
        CLI->>CLI: waitForServerState returns nil immediately
    else --wait set
        CLI->>User: stderr: Waiting for server sv_x
        CLI->>Poller: "ForServerState(want=[on], requireTransition=true)"
        loop poll every 2-15s
            Poller->>API: GET /servers/sv_x
            API-->>Poller: status
            alt "status==on and transition observed"
                Poller-->>CLI: success
            else "status==failed_deployment"
                Poller-->>CLI: ErrFailedState
            else timeout or cancel
                Poller-->>CLI: ErrTimeout/ErrCanceled
            end
        end
        CLI->>User: stderr: Server sv_x is now on
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["refactor(cli): address review — drop dea..."](https://github.com/latitudesh/cli/commit/10197109089501d2a994f2450fda572128e4e705) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41529928)</sub>

<!-- /greptile_comment -->